### PR TITLE
Solve the confirm password bug

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -49,7 +49,7 @@ class SignUpActivity : BaseActivity() {
             username = tiUsername.editText?.text.toString()
             email = tiEmail.editText?.text.toString()
             password = tiPassword.editText?.text.toString()
-            confirmedPassword = cbTC.text.toString()
+            confirmedPassword = tiConfirmPassword.editText?.text.toString()
 
             if (validateDetails()) {
                 val requestData = RegisterRequest(name, username, password, email, true)


### PR DESCRIPTION
### Description
I changed that the confirm password is being sent through the correct edit text. And now the confirm password is working all fine.

Fixes #34 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Here is the screen shot that now it works all fine
<img src = "https://user-images.githubusercontent.com/34381723/44232725-83fcac00-a1bf-11e8-9443-c6bb370b0052.png" width = 300>


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings