### PR TITLE
fix: Solve sign up email bug

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -52,7 +52,7 @@ class SignUpActivity : BaseActivity() {
             confirmedPassword = tiConfirmPassword.editText?.text.toString()
 
             if (validateDetails()) {
-                val requestData = RegisterRequest(name, username, password, email, true)
+                val requestData = RegisterRequest(name, username, email, password, true)
                 signUpViewModel.register(requestData)
                 showProgressDialog(getString(R.string.signing_up))
             }


### PR DESCRIPTION
### Description
Initially in the request register the email and the password were swapped and the email was going in the password field and vice versa hence we were getting an error that email is invalid. But now after solving this bug the problem is solved and the app is working as expected.

Fixes #37 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
<img src = "https://user-images.githubusercontent.com/34381723/44297298-a6d8ae80-a2ec-11e8-9ead-f27cf3f58e08.gif" width = 300>

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes