### PR TITLE
feat: logout and checking if user is already logged in

### DIFF
--- a/app/src/main/java/org/systers/mentorship/utils/PreferenceManager.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/PreferenceManager.kt
@@ -31,4 +31,11 @@ class PreferenceManager {
 
     val authToken: String
         get() = sharedPreferences.getString(AUTH_TOKEN, "")
+
+    /**
+     * Clears all the data that has been saved in the preferences file.
+     */
+    fun clear() {
+        sharedPreferences.edit().clear().apply()
+    }
 }

--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.systers.mentorship.view.activities
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.design.widget.BottomNavigationView
 import android.view.Menu
@@ -7,12 +8,15 @@ import android.view.MenuItem
 import kotlinx.android.synthetic.main.activity_main.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.BottomNavigationViewHelper
+import org.systers.mentorship.utils.PreferenceManager
 import org.systers.mentorship.view.fragments.*
 
 /**
  * This activity has the bottom navigation which allows the user to switch between fragments
  */
 class MainActivity : BaseActivity() {
+
+    private val preferenceManager: PreferenceManager = PreferenceManager()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -70,6 +74,13 @@ class MainActivity : BaseActivity() {
                     true
                 }
                 R.id.menu_feedback -> {
+                    true
+                }
+                R.id.menu_logout -> {
+                    preferenceManager.clear()
+                    intent = Intent(this, LoginActivity::class.java)
+                    startActivity(intent)
+                    finish()
                     true
                 }
                 else -> false

--- a/app/src/main/java/org/systers/mentorship/view/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SplashScreenActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.support.v7.app.AppCompatActivity
 import org.systers.mentorship.R
+import org.systers.mentorship.utils.PreferenceManager
 
 /**
  * This activity will show the organisation logo for sometime and then start the next activity
@@ -14,12 +15,17 @@ class SplashScreenActivity : AppCompatActivity() {
     private lateinit var handler: Handler
     private lateinit var runnable: Runnable
     private var SPLASH_DISPLAY_LENGTH: Long = 1000
+    private val preferenceManager: PreferenceManager = PreferenceManager()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash_screen)
 
-        val intent = Intent(this, LoginActivity::class.java)
+        val intent = if (preferenceManager.authToken.isEmpty()) {
+            Intent(this, LoginActivity::class.java)
+        } else {
+            Intent(this, MainActivity::class.java)
+        }
 
         runnable = Runnable {
             startActivity(intent)

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -13,4 +13,8 @@
         android:id="@+id/menu_feedback"
         android:title="@string/popup_menu_feedback"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/menu_logout"
+        android:icon="@android:drawable/ic_lock_power_off"
+        android:title="@string/popup_menu_logout" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="popup_menu_feedback">Feedback</string>
     <string name="popup_menu_about">About</string>
     <string name="popup_menu_settings">Settings</string>
+    <string name="popup_menu_logout">Logout</string>
     <string name="fragment_title_home">Home</string>
     <string name="fragment_title_members">Members</string>
     <string name="fragment_title_profile">My Profile</string>


### PR DESCRIPTION
### Description
Added logout button in pop-up menu. It cleares user's SharedPreferences and sends him to LoginActivity. Also, now user doesn't need to log in every time he opens the app. If his authtoken is saved, he will be redirected to MainActivity.

Fixes #44

### Type of Change:

- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
It was tested manually. Instead of redirecting to LoginActivity after Logout button is clicked, I tried redirecting to SplashScreenActivity. It worked as expected sending user to LoginActivity because there's no authtoken in SharedPreferences. Also, I tried logging in and closing the application. When I open it again, I see MainActivity and I'm not asked to log in again.

That's how pop-up menu looks like now:
![image](https://user-images.githubusercontent.com/38620564/44512052-060a3a80-a6c2-11e8-8850-d939e0f1096b.png)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings