### PR TITLE
Remove username from list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+app/src/main/java/org/systers/mentorship/view/.DS_Store
+app/src/main/java/org/systers/.DS_Store
+.DS_Store

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
@@ -14,6 +14,7 @@ import org.systers.mentorship.utils.CommonUtils
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
+import org.systers.mentorship.utils.getAuthTokenPayload
 
 /**
  * This class represents the [ViewModel] component used for the Members Activity
@@ -37,7 +38,11 @@ class MembersViewModel : ViewModel() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeWith(object : DisposableObserver<List<UserResponse>>() {
                     override fun onNext(userListResponse: List<UserResponse>) {
-                        usersList = userListResponse
+
+                        // Exclude current user from the list
+                        val currentUserId = getAuthTokenPayload().identity
+                        usersList = (userListResponse as ArrayList<UserResponse>).filter { userResponse -> userResponse.id != currentUserId }
+
                         successful.value = true
                     }
 

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
@@ -41,8 +41,11 @@ class MembersViewModel : ViewModel() {
 
                         // Exclude current user from the list
                         val currentUserId = getAuthTokenPayload().identity
-                        usersList = (userListResponse as ArrayList<UserResponse>).filter { userResponse -> userResponse.id != currentUserId }
+                        usersList = ArrayList<UserResponse>()
 
+                        if(userListResponse is ArrayList<UserResponse>){
+                            userListResponse.filter { userResponse -> userResponse.id != currentUserId }
+                        }
                         successful.value = true
                     }
 


### PR DESCRIPTION
### Description
When a user was signed in, the list of mentors/mentees used to show up with the user's own name. Thus, the user could request himself/herself as a mentor, and that did not make sense. 
I've removed the user's own username from the request list.

Fixes #61 

### Type of Change:
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I signed in with my own account and made sure that my username was removed from the list when I logged in. I asked someone else on the team to do this as well, and her username was removed from her list.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules