### PR TITLE
Fixes fragment reloading when app goes in landscape mode.

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -25,7 +25,9 @@ class MainActivity : BaseActivity() {
         bottomNavigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
         BottomNavigationViewHelper.disableShiftMode(bottomNavigation)
 
-        replaceFragment(R.id.contentFrame, HomeFragment.newInstance(), R.string.fragment_title_home)
+        if (savedInstanceState == null) {
+            replaceFragment(R.id.contentFrame, HomeFragment.newInstance(), R.string.fragment_title_home)
+        }
     }
 
     private val mOnNavigationItemSelectedListener =


### PR DESCRIPTION
### Description

I have fixed the following bug that When app goes in landscape mode the fragment is reloaded every time and the app gets stuck.

Fixes #76 
Fixes #60 

### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested on my Android Device. Below is the gif of the bug fixed.
![gif](https://user-images.githubusercontent.com/35039342/47258715-c347c180-d4bc-11e8-9abc-bda68939c593.gif)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
