### PR TITLE
Add mentor/mentee availability option on Sign Up

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/requests/RegisterRequest.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/RegisterRequest.kt
@@ -16,5 +16,7 @@ data class RegisterRequest (
         val username: String,
         val email: String,
         val password: String,
-        @SerializedName("terms_and_conditions_checked") val hasAcceptedTermsAndConditions: Boolean
+        @SerializedName("terms_and_conditions_checked") val hasAcceptedTermsAndConditions: Boolean,
+        @SerializedName("need_mentoring") val needsMentoring: Boolean,
+        @SerializedName("available_to_mentor") val isAvailableToMentor: Boolean
 )

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -24,6 +24,8 @@ class SignUpActivity : BaseActivity() {
     private lateinit var email: String
     private lateinit var password: String
     private lateinit var confirmedPassword: String
+    private var isAvailableToMentor: Boolean = false
+    private var needsMentoring: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -50,9 +52,11 @@ class SignUpActivity : BaseActivity() {
             email = tiEmail.editText?.text.toString()
             password = tiPassword.editText?.text.toString()
             confirmedPassword = tiConfirmPassword.editText?.text.toString()
+            needsMentoring = cbMentee.isChecked
+            isAvailableToMentor = cbMentor.isChecked
 
             if (validateDetails()) {
-                val requestData = RegisterRequest(name, username, email, password, true)
+                val requestData = RegisterRequest(name, username, email, password, true, needsMentoring, isAvailableToMentor)
                 signUpViewModel.register(requestData)
                 showProgressDialog(getString(R.string.signing_up))
             }

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fillViewport="true">
 
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
@@ -11,33 +12,29 @@
         tools:context="org.systers.mentorship.view.activities.SignUpActivity">
 
         <android.support.v7.widget.AppCompatTextView
-            android:id="@+id/textView"
+            android:id="@+id/tvSignUp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
             android:layout_marginStart="8dp"
             android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
             android:text="@string/sign_up"
             android:textSize="24sp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.501"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tiName"
-            android:layout_width="272dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
-            android:layout_marginBottom="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="48dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="48dp"
             android:hint="@string/name"
-            app:layout_constraintBottom_toTopOf="@+id/tiUsername"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView"
-            app:layout_constraintVertical_bias="1.0">
+            app:layout_constraintTop_toBottomOf="@+id/tvSignUp">
 
             <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
@@ -47,33 +44,29 @@
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tiUsername"
-            android:layout_width="272dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:hint="@string/username"
-            app:layout_constraintBottom_toTopOf="@+id/tiEmail"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintEnd_toEndOf="@+id/tiName"
+            app:layout_constraintStart_toStartOf="@+id/tiName"
+            app:layout_constraintTop_toBottomOf="@id/tiName">
 
             <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text"/>
+                android:inputType="text" />
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tiEmail"
-            android:layout_width="272dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:hint="@string/email"
-            app:layout_constraintBottom_toTopOf="@+id/tiPassword"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintEnd_toEndOf="@+id/tiUsername"
+            app:layout_constraintStart_toStartOf="@+id/tiUsername"
+            app:layout_constraintTop_toBottomOf="@id/tiUsername">
 
             <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
@@ -83,80 +76,105 @@
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tiPassword"
-            android:layout_width="272dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:hint="@string/password"
-            app:passwordToggleEnabled="true"
-            app:layout_constraintBottom_toTopOf="@+id/tiConfirmPassword"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintEnd_toEndOf="@+id/tiEmail"
+            app:layout_constraintStart_toStartOf="@+id/tiEmail"
+            app:layout_constraintTop_toBottomOf="@id/tiEmail"
+            app:passwordToggleEnabled="true">
 
             <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword"/>
+                android:inputType="textPassword" />
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/tiConfirmPassword"
-            android:layout_width="272dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:hint="@string/confirm_password"
-            app:passwordToggleEnabled="true"
-            app:layout_constraintBottom_toTopOf="@+id/cbTC"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintEnd_toEndOf="@+id/tiPassword"
+            app:layout_constraintStart_toStartOf="@+id/tiPassword"
+            app:layout_constraintTop_toBottomOf="@id/tiPassword"
+            app:passwordToggleEnabled="true">
 
             <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:inputType="textPassword"/>
+                android:inputType="textPassword" />
         </android.support.design.widget.TextInputLayout>
+
+        <android.support.v7.widget.AppCompatTextView
+            android:id="@+id/appCompatTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/available_to_be_mentor_mentee"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="@+id/tiConfirmPassword"
+            app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
+            app:layout_constraintTop_toBottomOf="@+id/tiConfirmPassword" />
+
+        <android.support.v7.widget.AppCompatCheckBox
+            android:id="@+id/cbMentor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/mentor"
+            app:layout_constraintEnd_toStartOf="@+id/cbMentee"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
+            app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
+
+        <android.support.v7.widget.AppCompatCheckBox
+            android:id="@+id/cbMentee"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/mentee"
+            app:layout_constraintEnd_toEndOf="@+id/tiConfirmPassword"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/cbMentor"
+            app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
 
         <android.support.v7.widget.AppCompatCheckBox
             android:id="@+id/cbTC"
-            android:layout_width="271dp"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="24dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:text="@string/terms_and_conditions_acceptance_statement"
-            app:layout_constraintBottom_toTopOf="@+id/btnSignUp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.505"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintEnd_toEndOf="@+id/tiConfirmPassword"
+            app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
+            app:layout_constraintTop_toBottomOf="@+id/cbMentee" />
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/btnSignUp"
             style="@style/Widget.AppCompat.Button.Colored"
-            android:enabled="false"
             android:layout_width="168dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="68dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:enabled="false"
             android:text="@string/sign_up"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintEnd_toEndOf="@+id/cbTC"
+            app:layout_constraintStart_toStartOf="@+id/cbTC"
+            app:layout_constraintTop_toBottomOf="@id/cbTC" />
 
         <android.support.v7.widget.AppCompatButton
             android:id="@+id/btnLogin"
             style="@style/Widget.AppCompat.Button.Borderless.Colored"
             android:layout_width="167dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
             android:text="@string/login"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintEnd_toEndOf="@+id/btnSignUp"
+            app:layout_constraintStart_toStartOf="@+id/btnSignUp"
+            app:layout_constraintTop_toBottomOf="@id/btnSignUp" />
     </android.support.constraint.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,4 +93,5 @@
     <string name="i_will_be_a">I will be a ...</string>
     <string name="end_date_format">dd/mm/YYYY</string>
     <string name="no_current_mentorship_relation">You are not in a current mentorship relation.</string>
+    <string name="available_to_be_mentor_mentee">Available to be a:</string>
 </resources>


### PR DESCRIPTION
### Description
Modified the activity layout to include two additional checkboxes for Mentor/Mentee availability, and also added these two state variables to the RegisterRequest data class. The SignUpActivity now passes these two parameters to the register request, based on the state of the check boxes.

Fixes #64 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

## Screenshot of changes:
![mentor_mentee_feature](https://user-images.githubusercontent.com/24315306/47496828-acff8400-d875-11e8-94b9-e32a4633dbc5.jpg)

### How Has This Been Tested?
Tested sign up flow on personal device

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or material

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes