### PR TITLE
fix: User can update mentor/mentee availability

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -8,14 +8,12 @@ import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
 import android.support.v7.app.AlertDialog
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.Switch
 import android.widget.Toast
-import kotlinx.android.synthetic.main.fragment_edit_profile.*
-
 import org.systers.mentorship.R
 import org.systers.mentorship.databinding.FragmentEditProfileBinding
 import org.systers.mentorship.models.User
@@ -26,6 +24,9 @@ import org.systers.mentorship.viewmodels.ProfileViewModel
  * The fragment is responsible for editing the User's profile
  */
 class EditProfileFragment: DialogFragment() {
+
+    private lateinit var mentorSwitch: Switch
+    private lateinit var menteeSwitch: Switch
 
     companion object {
         private lateinit var tempUser: User
@@ -51,13 +52,13 @@ class EditProfileFragment: DialogFragment() {
             if (successful != null) {
                 if (successful) {
                     Toast.makeText(context,getText(R.string.update_successful),Toast.LENGTH_LONG).show()
+                    profileViewModel.getProfile()
                     dismiss()
                 } else {
                     Toast.makeText(activity, profileViewModel.message, Toast.LENGTH_SHORT).show()
                 }
             }
         })
-
         dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         isCancelable = false
         return inflater.inflate(R.layout.fragment_edit_profile, container, false)
@@ -83,10 +84,20 @@ class EditProfileFragment: DialogFragment() {
         super.onResume()
 
         val editProfileDialog = dialog as AlertDialog
+
+        mentorSwitch = editProfileBinding.switchAvailableToMentor.findViewById(R.id.switchAvailableToMentor)
+        menteeSwitch = editProfileBinding.switchNeedsMentoring.findViewById(R.id.switchNeedsMentoring)
+
+        mentorSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
+            editProfileBinding.user?.isAvailableToMentor = isChecked
+        }
+
+        menteeSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
+            editProfileBinding.user?.needsMentoring = isChecked
+        }
+
         editProfileDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
             // TODO: Add validation
-            editProfileBinding.user?.isAvailableToMentor = switchAvailableToMentor.isChecked
-            editProfileBinding.user?.needsMentoring = switchNeedsMentoring.isChecked
             if (currentUser != editProfileBinding.user) {
                 profileViewModel.updateProfile(editProfileBinding.user!!)
             } else {


### PR DESCRIPTION
### Description
Now User can update mentor or mentee availability from EditProfile and after saving the changes he/she can instantly see the changes.

Fixes #95 

### Type of Change:
**Delete irrelevant options.**

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on my Android device and verified that feature is working fine. Here is the GIF.
![prgif](https://user-images.githubusercontent.com/35039342/48374323-88ffc780-e6ea-11e8-8896-9d2d1a7eb80c.gif)




### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
