### PR TITLE
fix: setting menu icon in a fixed position

### DIFF
--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -5,5 +5,6 @@
         android:id="@+id/menu_settings"
         android:title="@string/popup_menu_settings"
         app:showAsAction="always"
+        android:menuCategory="container"
         android:icon="@drawable/ic_settings_white_24dp"/>
 </menu>


### PR DESCRIPTION
### Description
The transition to the profile activity looked strange because of the settings item on the menu that was originally on the right moved to the left when the edit button was added.

Fixes issue #106 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I created an emulated Pixel 2 with API 27, and I saw that the menu items were in the correct order once this change was made. 

| Menu Items in Original Order | Menu Items in Modified Order |
| --- | --- |
|<img width=320 src=https://user-images.githubusercontent.com/7873908/49679775-1fee4400-fa4b-11e8-90fd-94f0e59d8d87.png>|<img width=320 src=https://user-images.githubusercontent.com/7873908/49679781-2a104280-fa4b-11e8-8d30-3628994faa9f.png>|

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [X] My changes generate no new warnings