### PR TITLE
fix: Add input validation to EditProfileFragment

### DIFF
--- a/app/src/main/java/org/systers/mentorship/utils/States.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/States.kt
@@ -1,0 +1,28 @@
+package org.systers.mentorship.utils
+
+/**
+ * A sealed class to represent error states
+ * in the EditProfileFragment. More error states
+ * can be added in the future as the application
+ * grows in complexity.
+ */
+sealed class EditProfileFragmentErrorStates {
+
+    /**
+     * An object to represent the error case when the
+     * entered name of the user is empty.
+     */
+    object EmptyNameError: EditProfileFragmentErrorStates()
+
+    /**
+     * An object to represent the error case when the
+     * entered name of the user is too short.
+     */
+    object NameTooShortError: EditProfileFragmentErrorStates()
+
+    /**
+     * An object to represent the error case when the
+     * entered name of the user is too long.
+     */
+    object NameTooLongError: EditProfileFragmentErrorStates()
+}

--- a/app/src/main/res/values/constants.xml
+++ b/app/src/main/res/values/constants.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="min_name_length">2</integer>
+    <integer name="max_name_length">30</integer>
+</resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,4 +99,6 @@
     <string name="notes_empty_error">Notes cannot be empty</string>
     <string name="available_to_be_mentor_mentee">Available to be a:</string>
     <string name="settings">Settings</string>
+    <string name="error_name_too_short">Name should have a minimum of %1$d characters</string>
+    <string name="error_name_too_long">Name should have a maximum of %1$d characters</string>
 </resources>


### PR DESCRIPTION
This commit adds input validation to the EditProfileFragment.

### Description
An extra file called States.kt has been created to represent possible
error states (there is only one right now). More errors can be added to
this class as the application grows and the number of required fields in
a profile increases.

Fixes #110 

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on my phone. Attached a screenshot to show implementation of this feature.
![image 2018-12-11 11 45 19](https://user-images.githubusercontent.com/24315306/49781859-3e4d8b80-fd3a-11e8-89fe-fcda7628bea8.jpg)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings