### PR TITLE
Add new mentorship task screen

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity: BaseActivity() {
                 return@OnNavigationItemSelectedListener true
             }
             R.id.navigation_relation -> {
-                replaceFragment(R.id.contentFrame, RelationFragment.newInstance(),
+                replaceFragment(R.id.contentFrame, RelationPagerFragment.newInstance(),
                         R.string.fragment_title_relation)
                 atHome = false
                 return@OnNavigationItemSelectedListener true

--- a/app/src/main/java/org/systers/mentorship/view/adapters/RelationPagerAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/RelationPagerAdapter.kt
@@ -1,0 +1,55 @@
+package org.systers.mentorship.view.adapters
+
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+import android.support.v4.app.FragmentPagerAdapter
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.view.fragments.RelationFragment
+import org.systers.mentorship.view.fragments.TasksFragment
+
+/**
+ * This is the [FragmentPagerAdapter] responsible for the configuration each fragment assigned to
+ * each tabs. One tab displays the details of the current mentorship relation and the other provides
+ * a detailed information about the tasks.
+ * @param fm fragment manager
+ */
+class RelationPagerAdapter(fm: FragmentManager) : FragmentPagerAdapter(fm) {
+
+    /**
+     * This class represents the number and index of each tab of the layout
+     */
+    enum class TabsIndex(val value: Int) {
+        DETAILS(0),
+        TASKS(1)
+    }
+
+    val context = MentorshipApplication.getContext()
+
+    override fun getItem(position: Int): Fragment {
+        when (position) {
+            TabsIndex.DETAILS.value -> {
+                return RelationFragment.newInstance()
+            }
+
+            TabsIndex.TASKS.value -> {
+                return TasksFragment.newInstance()
+            }
+        }
+        return TasksFragment.newInstance()
+    }
+
+    override fun getCount(): Int = 2
+
+    override fun getPageTitle(position: Int): CharSequence? {
+        when (position) {
+            RequestsPagerAdapter.TabsIndex.PENDING.value -> {
+                return context.getString(R.string.details)
+            }
+            RequestsPagerAdapter.TabsIndex.PAST.value -> {
+                return context.getString(R.string.tasks)
+            }
+        }
+        return context.getString(R.string.details)
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
@@ -1,0 +1,43 @@
+package org.systers.mentorship.view.adapters
+
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.task_list_item.view.*
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+
+/**
+ * This class represents the adapter that fills in each view of the Tasks recyclerView
+ * @param taskstsList list of tasks taken up by the mentee
+ * @param markTask function to be called when an item from Tasks list is clicked
+ */
+class TasksAdapter(
+        private val tasksList: List<String>,
+        private val markTask: (taskId: Int) -> Unit
+) : RecyclerView.Adapter<TasksAdapter.TaskViewHolder>() {
+
+    val context = MentorshipApplication.getContext();
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TasksAdapter.TaskViewHolder =
+            TasksAdapter.TaskViewHolder(
+                    LayoutInflater.from(parent.context)
+                            .inflate(R.layout.task_list_item, parent, false))
+
+    override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
+        val item = tasksList[position]
+        val itemView = holder.itemView ?: return
+        itemView.cbTask.text = item
+
+        itemView.setOnClickListener { markTask(position) }
+    }
+
+    override fun getItemCount(): Int = tasksList.size
+
+    /**
+     * This class holds a view for each item of the Tasks list
+     * @param itemView represents each view of Tasks list
+     */
+    class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+}

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.text.method.ScrollingMovementMethod
 import android.view.View
-import kotlinx.android.synthetic.main.fragment_relation.*
+import kotlinx.android.synthetic.main.fragment_relation_pager.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.utils.EXTENDED_DATE_FORMAT
@@ -31,7 +31,7 @@ class RelationFragment : BaseFragment() {
     private val activityCast by lazy { activity as MainActivity }
 
     override fun getLayoutResourceId(): Int {
-        return R.layout.fragment_relation
+        return R.layout.fragment_relation_pager
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
@@ -1,0 +1,29 @@
+package org.systers.mentorship.view.fragments
+
+import android.os.Bundle
+import kotlinx.android.synthetic.main.fragment_relation.*
+import org.systers.mentorship.R
+import org.systers.mentorship.view.adapters.RelationPagerAdapter
+
+/**
+ * This fragment is instantiated per each tab from the RelationFragment ViewPager
+ */
+class RelationPagerFragment : BaseFragment() {
+
+    companion object {
+        /**
+         * Creates an instance of [RelationPagerFragment]
+         */
+        fun newInstance() = RelationPagerFragment()
+    }
+
+    override fun getLayoutResourceId(): Int {
+        return R.layout.fragment_relation
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        vpMentorshipRelation.adapter = RelationPagerAdapter(childFragmentManager)
+        tlMentorshipRelation.setupWithViewPager(vpMentorshipRelation)
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -1,0 +1,76 @@
+package org.systers.mentorship.view.fragments
+
+import android.app.AlertDialog
+import android.arch.lifecycle.ViewModelProviders
+import android.os.Bundle
+import android.support.v7.widget.LinearLayoutManager
+import android.widget.EditText
+import kotlinx.android.synthetic.main.fragment_mentorship_tasks.*
+import kotlinx.android.synthetic.main.task_list_item.*
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.view.activities.MainActivity
+import org.systers.mentorship.view.adapters.TasksAdapter
+import org.systers.mentorship.viewmodels.TasksViewModel
+
+/**
+ * The fragment is responsible for showing the all mentorship tasks
+ * and achievements. It also allows to add new tasks.
+ */
+class TasksFragment : BaseFragment() {
+
+    companion object {
+        /**
+         * Creates an instance of [TasksFragment]
+         */
+        fun newInstance() = TasksFragment()
+        val TAG = TasksFragment::class.java.simpleName
+    }
+
+    val appContext = MentorshipApplication.getContext()
+
+    private lateinit var taskViewModel: TasksViewModel
+
+    override fun getLayoutResourceId(): Int = R.layout.fragment_mentorship_tasks;
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
+        taskViewModel.getTasks()
+
+        rvTasks.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = TasksAdapter(taskViewModel.taskList, markTask)
+        }
+
+        ivAddItem.setOnClickListener {
+            showDialog()
+        }
+    }
+
+    /**
+     * The function creates a dialog box through whoch new tasks can be added
+     */
+    fun showDialog() {
+        val builder = AlertDialog.Builder(context)
+        val inflater = layoutInflater
+        builder.setTitle(appContext.getString(R.string.add_new_task))
+        val dialogLayout = inflater.inflate(R.layout.dialog_add_task, null)
+        val editText = dialogLayout.findViewById<EditText>(R.id.etAddTask)
+        builder.setView(dialogLayout)
+        builder.setPositiveButton(appContext.getString(R.string.save)) { dialogInterface, i ->
+            val newTask: String = editText.text.toString()
+            taskViewModel.addTask(newTask)
+        }
+        builder.setNegativeButton(appContext.getString(R.string.cancel)) { dialogInterface, i ->
+            dialogInterface.dismiss()
+        }
+        builder.show()
+    }
+
+    private val markTask: (Int) -> Unit = { taskId ->
+        cbTask.isChecked
+        taskViewModel.updateTask(taskId, cbTask.isChecked)
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
@@ -1,0 +1,48 @@
+package org.systers.mentorship.viewmodels
+
+import android.arch.lifecycle.ViewModel
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+
+/**
+ * This class represents the [ViewModel] used for Tasks Screen
+ */
+class TasksViewModel: ViewModel() {
+    var taskList = mutableListOf<String>()
+    var completedTaskList = mutableListOf<String>()
+
+    /**
+     * This function lists all tasks from the mentorship relation
+     */
+    fun getTasks() {
+        taskList.add(MentorshipApplication.getContext().getString(R.string.model_task_1))
+        taskList.add(MentorshipApplication.getContext().getString(R.string.model_task_2))
+        taskList.add(MentorshipApplication.getContext().getString(R.string.model_task_3))
+        //TODO: Fetch the list from the backend
+    }
+
+    /**
+     * This function helps in adds a new task to the task list
+     * @param taskName title of the new task
+     */
+    fun addTask(taskName: String) {
+        taskList.add(taskName)
+        //TODO: Update the backend
+    }
+
+    /**
+     * This function helps in updating completed tasks
+     * @param taskId id of the task that is clicked
+     * @param isChecked boolean value to specify if the task was marked or unmarked
+     */
+    fun updateTask(taskId: Int, isChecked: Boolean){
+        if(isChecked) {
+            completedTaskList.add(taskList.get(taskId))
+            //TODO: Update the backend
+        }
+        else {
+            completedTaskList.remove(taskList.get(taskId))
+            //TODO: Update the backend
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard_arrow_down_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_down_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#DFDBD6"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7.41,7.84L12,12.42l4.59,-4.58L18,9.25l-6,6 -6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard_arrow_up_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_keyboard_arrow_up_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#DFDBD6"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_add_task.xml
+++ b/app/src/main/res/layout/dialog_add_task.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.v7.widget.AppCompatEditText
+        android:id="@+id/etAddTask"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_mentorship_tasks.xml
+++ b/app/src/main/res/layout/fragment_mentorship_tasks.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvTodo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="To do"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:textSize="18sp"/>
+
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:id="@+id/rvTasks"
+        app:layout_constraintTop_toBottomOf="@id/tvTodo"
+        app:layout_constraintVertical_weight="0.5"
+        android:layout_marginLeft="16dp"/>
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/ivAddItem"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rvTasks"
+        app:srcCompat="@drawable/ic_add_black_24dp" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvAddNewItem"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add a new item"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toEndOf="@+id/ivAddItem"
+        app:layout_constraintTop_toBottomOf="@+id/rvTasks"
+        android:textSize="18sp"
+        android:layout_marginLeft="8dp"/>
+
+    <View
+        android:id="@+id/view"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:background="@color/colorPrimary"
+        app:layout_constraintTop_toBottomOf="@id/tvAddNewItem"
+        android:layout_marginTop="8dp"
+        android:backgroundTint="#D3D3D3"/>
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvAchievements"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="Achievements"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/view" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rvAchievements"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintVertical_weight="0.5"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintTop_toBottomOf="@id/tvAchievements"/>
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/imageView"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/tvTodo"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp" />
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/imageView2"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toEndOf="@+id/tvAchievements"
+        app:layout_constraintTop_toTopOf="@+id/view"
+        app:srcCompat="@drawable/ic_keyboard_arrow_down_black_24dp" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_relation.xml
+++ b/app/src/main/res/layout/fragment_relation.xml
@@ -1,133 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <android.support.v7.widget.AppCompatButton
-        android:id="@+id/btnCancelRelation"
-        style="@style/Widget.AppCompat.Button.Borderless.Colored"
-        android:layout_width="wrap_content"
+    <android.support.design.widget.TabLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:text="@string/cancel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvMenteeLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="16dp"
-        android:text="Mentee:"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tvMentorLabel" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvMentorLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="32dp"
-        android:text="Mentor:"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvEndDateLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="16dp"
-        android:text="End date:"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tvMenteeLabel" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvNotesLabel"
-        android:layout_width="295dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:layout_marginTop="16dp"
-        android:text="Notes:"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tvEndDateLabel" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvMentorName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="32dp"
-        tools:text="TextView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.058"
-        app:layout_constraintStart_toEndOf="@+id/tvMentorLabel"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvMenteeName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        tools:text="TextView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.044"
-        app:layout_constraintStart_toEndOf="@+id/tvMenteeLabel"
-        app:layout_constraintTop_toBottomOf="@+id/tvMentorName" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvEndDate"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        tools:text="TextView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.01"
-        app:layout_constraintStart_toEndOf="@+id/tvEndDateLabel"
-        app:layout_constraintTop_toBottomOf="@+id/tvMenteeName" />
-
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvRelationNotes"
-        android:layout_width="296dp"
-        android:layout_height="215dp"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:scrollbars="vertical"
-        android:fadeScrollbars="false"
-        tools:text="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not onlyt of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also th five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-        app:layout_constraintBottom_toTopOf="@+id/btnCancelRelation"
+        android:id="@+id/tlMentorshipRelation"
+        app:tabSelectedTextColor="@color/colorAccent"
+        app:tabIndicatorColor="@color/colorAccent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tvNotesLabel"
-        app:layout_constraintVertical_bias="0.056" />
+        app:layout_constraintTop_toTopOf="parent"/>
 
-    <android.support.v7.widget.AppCompatTextView
-        android:id="@+id/tvNoCurrentRelation"
-        android:layout_width="250dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/no_current_mentorship_relation"
-        android:textAlignment="center"
-        android:textSize="24sp"
+    <android.support.v4.view.ViewPager
+        android:id="@+id/vpMentorshipRelation"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/tlMentorshipRelation" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_relation_pager.xml
+++ b/app/src/main/res/layout/fragment_relation_pager.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.AppCompatButton
+        android:id="@+id/btnCancelRelation"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/cancel"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvMenteeLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:text="Mentee:"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvMentorLabel" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvMentorLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="32dp"
+        android:text="Mentor:"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvEndDateLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:text="End date:"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvMenteeLabel" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvNotesLabel"
+        android:layout_width="295dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:text="Notes:"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvEndDateLabel" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvMentorName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="32dp"
+        tools:text="TextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.058"
+        app:layout_constraintStart_toEndOf="@+id/tvMentorLabel"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvMenteeName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        tools:text="TextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.044"
+        app:layout_constraintStart_toEndOf="@+id/tvMenteeLabel"
+        app:layout_constraintTop_toBottomOf="@+id/tvMentorName" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvEndDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        tools:text="TextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.01"
+        app:layout_constraintStart_toEndOf="@+id/tvEndDateLabel"
+        app:layout_constraintTop_toBottomOf="@+id/tvMenteeName" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvRelationNotes"
+        android:layout_width="296dp"
+        android:layout_height="215dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:scrollbars="vertical"
+        android:fadeScrollbars="false"
+        app:layout_constraintBottom_toTopOf="@+id/btnCancelRelation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvNotesLabel"
+        app:layout_constraintVertical_bias="0.056" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvNoCurrentRelation"
+        android:layout_width="250dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/no_current_mentorship_relation"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/task_list_item.xml
+++ b/app/src/main/res/layout/task_list_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <CheckBox
+        android:id="@+id/cbTask"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="CheckBox"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,4 +101,10 @@
     <string name="settings">Settings</string>
     <string name="error_name_too_short">Name should have a minimum of %1$d characters</string>
     <string name="error_name_too_long">Name should have a maximum of %1$d characters</string>
+    <string name="model_task_1">Add Projects section to CV</string>
+    <string name="model_task_2">Prepare questions for Job Interview X</string>
+    <string name="model_task_3">Share a Professional update on Twitter</string>
+    <string name="details">Details</string>
+    <string name="tasks">Tasks</string>
+    <string name="add_new_task">Add a new task</string>
 </resources>


### PR DESCRIPTION
### Description
The pull request adds another pager fragment to show the tasks taken up by the mentee.
The changes inculde:
- Development of the screen as shown in the mock
- Addition of another tasks fragment
- Addition of ViewModel with proper to handle the backened interaction
- Mechanism to add more tasks

Fixes #18 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

![videotogif_2018 12 25_17 24 39](https://user-images.githubusercontent.com/26908195/50423478-db044300-087b-11e9-8d74-34cf7bf1155d.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules