### PR TITLE
feat: Add user statistics to home screen

### DIFF
--- a/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
+++ b/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
@@ -1,0 +1,34 @@
+package org.systers.mentorship.models
+
+import android.annotation.SuppressLint
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * This class represents statistics of the user actions on the app.
+ * @param name the name of the user
+ * @param pendingRequests number of pending requests
+ * @param acceptedRequests number of accepted requests
+ * @param completedRelations number of completed relations
+ * @param cancelledRelations number of cancelled relations
+ * @param rejectedRequests number of rejected requests
+ * @param achievements a list of up-to 3 completed tasks
+ */
+
+@SuppressLint("ParcelCreator")
+@Parcelize
+data class HomeStatistics(
+        val name: String,
+        @SerializedName("pending_requests")
+        val pendingRequests: Int,
+        @SerializedName("accepted_requests")
+        val acceptedRequests: Int,
+        @SerializedName("completed_relations")
+        val completedRelations: Int,
+        @SerializedName("cancelled_relations")
+        val cancelledRelations: Int,
+        @SerializedName("rejected_requests")
+        val rejectedRequests: Int,
+        val achievements: List<Task>): Parcelable
+

--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -1,0 +1,31 @@
+package org.systers.mentorship.models
+
+import android.annotation.SuppressLint
+import android.os.Parcelable
+import com.google.gson.annotations.SerializedName
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * This data class represents a task related to a mentorship
+ * relation.
+ *
+ * @param id The id of this task
+ * @param description The description of this task
+ * @param isDone Represents whether this task has been completed
+ * @param createdAt Unix timestamp of when this task was created
+ * @param completedAt Unix timestamp of when this task was completed
+ */
+
+@SuppressLint("ParcelCreator")
+@Parcelize
+data class Task(
+        val id: Int,
+        val description: String,
+        @SerializedName("is_done")
+        val isDone: Boolean,
+        @SerializedName("created_at")
+        val createdAt: Float,
+        @SerializedName("completed_at")
+        val completedAt: Float
+): Parcelable
+

--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/UserDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/UserDataManager.kt
@@ -1,6 +1,7 @@
 package org.systers.mentorship.remote.datamanager
 
 import io.reactivex.Observable
+import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.ApiManager
 import org.systers.mentorship.remote.requests.ChangePassword
@@ -51,5 +52,13 @@ class UserDataManager {
      */
     fun updatePassword(changePassword: ChangePassword): Observable<CustomResponse> {
         return apiManager.userService.updatePassword(changePassword)
+    }
+
+    /**
+     * This function fetches user statistics
+     * @return an observable of [HomeStatistics]
+     */
+    fun getHomeStats(): Observable<HomeStatistics> {
+        return apiManager.userService.getHomeStats()
     }
 }

--- a/app/src/main/java/org/systers/mentorship/remote/services/UserService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/UserService.kt
@@ -1,6 +1,7 @@
 package org.systers.mentorship.remote.services
 
 import io.reactivex.Observable
+import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.requests.ChangePassword
 import org.systers.mentorship.remote.responses.CustomResponse
@@ -55,4 +56,11 @@ interface UserService {
      */
     @PUT("user/change_password")
     fun updatePassword(@Body changePassword: ChangePassword): Observable<CustomResponse>
+
+    /**
+     * This function gets the current user's home screen statistics
+     * @return an observable instance of [HomeStatistics]
+     */
+    @GET("home")
+    fun getHomeStats(): Observable<HomeStatistics>
 }

--- a/app/src/main/java/org/systers/mentorship/utils/SingleLiveEvent.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/SingleLiveEvent.kt
@@ -1,0 +1,59 @@
+package org.systers.mentorship.utils
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import android.support.annotation.MainThread
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+
+/**
+ * A lifecycle-aware observable that sends only new updates after subscription, used for events like
+ * navigation and Snackbar messages.
+ *
+ *
+ * This avoids a common problem with events: on configuration change (like rotation) an update
+ * can be emitted if the observer is active. This LiveData only calls the observable if there's an
+ * explicit call to setValue() or call().
+ *
+ *
+ * Note that only one observer is going to be notified of changes.
+ */
+class SingleLiveEvent<T> : MutableLiveData<T>() {
+
+    companion object {
+        private val TAG = this::class.java.simpleName
+    }
+
+    private val mPending = AtomicBoolean(false)
+
+    @MainThread
+    override fun observe(owner: LifecycleOwner, observer: Observer<T>) {
+
+        if (hasActiveObservers()) {
+            Log.w(TAG, "Multiple observers registered but only one will be notified of changes.")
+        }
+
+        super.observe(owner, Observer<T> { t ->
+            if (mPending.compareAndSet(true, false)) {
+                observer.onChanged(t)
+            }
+        })
+    }
+
+    @MainThread
+    override fun setValue(t: T?) {
+        mPending.set(true)
+        super.setValue(t)
+    }
+
+    /**
+     * Used for cases where T is Void, to make calls cleaner.
+     */
+    @MainThread
+    fun call() {
+        value = null
+    }
+}
+

--- a/app/src/main/java/org/systers/mentorship/view/adapters/AchievementsAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/AchievementsAdapter.kt
@@ -1,0 +1,56 @@
+package org.systers.mentorship.view.adapters
+
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.achievement_list_item.view.*
+import org.systers.mentorship.R
+import org.systers.mentorship.models.Task
+
+/**
+ * This class is the RecyclerView adapter for achievements. It is a subclass of [ListAdapter] for
+ * easy async calculation of diffs using DiffUtil to provide nice animations when the data set
+ * changes.
+ */
+class AchievementsAdapter : ListAdapter<Task, AchievementsAdapter.ViewHolder>(AchievementsItemCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AchievementsAdapter.ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.achievement_list_item, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: AchievementsAdapter.ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    /**
+     * This class holds a view for each item of the Achievements list
+     * @param itemView represents each view of achievements list
+     */
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+        /**
+         * This function binds the description of the achievement to the textview
+         * @param task The Achievement whose description is to be bound
+         */
+        fun bind(task: Task) {
+            itemView.tvDescription.text = task.description
+        }
+    }
+
+}
+
+/**
+ * This class represents the DiffCallback for tasks, and is used in [AchievementsAdapter]
+ */
+class AchievementsItemCallback : DiffUtil.ItemCallback<Task>() {
+
+    override fun areItemsTheSame(oldItem: Task, newItem: Task) = oldItem.id == newItem.id
+
+    override fun areContentsTheSame(oldItem: Task, newItem: Task) = oldItem == newItem
+
+}
+

--- a/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
@@ -1,12 +1,30 @@
 package org.systers.mentorship.view.fragments
 
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProviders
+import android.databinding.DataBindingUtil
+import android.os.Bundle
+import android.support.design.widget.Snackbar
+import android.support.v7.widget.DividerItemDecoration
+import android.support.v7.widget.LinearLayoutManager
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_home.*
 import org.systers.mentorship.R
+import org.systers.mentorship.databinding.FragmentHomeBinding
+import org.systers.mentorship.view.adapters.AchievementsAdapter
+import org.systers.mentorship.viewmodels.HomeViewModel
 
 /**
  * The fragment is responsible for showing a welcoming message and show some statistics of the User
  * usage of the app
  */
 class HomeFragment : BaseFragment() {
+
+    private lateinit var homeViewModel: HomeViewModel
+    private lateinit var binding: FragmentHomeBinding
+    private lateinit var achievementsAdapter: AchievementsAdapter
 
     companion object {
         /**
@@ -17,4 +35,47 @@ class HomeFragment : BaseFragment() {
     }
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_home
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = DataBindingUtil.inflate(inflater, getLayoutResourceId(), container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        achievementsAdapter = AchievementsAdapter()
+        val linearLayoutManager = LinearLayoutManager(context)
+        val divider = DividerItemDecoration(context, linearLayoutManager.orientation)
+
+        rvAchievements.apply {
+            adapter = achievementsAdapter
+            layoutManager = linearLayoutManager
+            addItemDecoration(divider)
+        }
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        homeViewModel = ViewModelProviders.of(this).get(HomeViewModel::class.java)
+
+        with(homeViewModel) {
+            userStats.observe(viewLifecycleOwner, Observer { stats ->
+                binding.stats = stats
+                if (stats?.achievements?.isEmpty() != false) {
+                    tvNoAchievements.visibility = View.VISIBLE
+                    rvAchievements.visibility = View.GONE
+                } else {
+                    tvNoAchievements.visibility = View.GONE
+                    rvAchievements.visibility = View.VISIBLE
+                    achievementsAdapter.submitList(stats.achievements)
+                }
+            })
+
+            message.observe(viewLifecycleOwner, Observer { message ->
+                Snackbar.make(homeContainer, message.toString(), Snackbar.LENGTH_SHORT).show()
+            })
+        }
+    }
 }
+

--- a/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
@@ -1,0 +1,86 @@
+package org.systers.mentorship.viewmodels
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import android.util.Log
+import io.reactivex.Observer
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.observers.DisposableObserver
+import io.reactivex.rxkotlin.addTo
+import io.reactivex.schedulers.Schedulers
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.models.HomeStatistics
+import org.systers.mentorship.remote.datamanager.UserDataManager
+import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.SingleLiveEvent
+import retrofit2.HttpException
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+
+/**
+ * This class represents the ViewModel for the HomeFragment
+ */
+class HomeViewModel : ViewModel() {
+
+    private val TAG = this::class.java.simpleName
+    private val userDataManager by lazy { UserDataManager() }
+    private val compositeDisposable by lazy { CompositeDisposable() }
+
+    private val _userStats = MutableLiveData<HomeStatistics>()
+    private val _message = SingleLiveEvent<String>()
+
+    val userStats: LiveData<HomeStatistics>
+        get() = _userStats
+
+    val message: LiveData<String>
+        get() = _message
+
+    init {
+        userDataManager.getHomeStats()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeWith(object: DisposableObserver<HomeStatistics>() {
+
+                    override fun onComplete() {
+                        // Do nothing
+                    }
+
+                    override fun onNext(statistics: HomeStatistics) {
+                        _userStats.value = statistics
+                    }
+
+                    override fun onError(error: Throwable) {
+                        when (error) {
+                            is IOException -> {
+                                _message.postValue(MentorshipApplication.getContext()
+                                        .getString(R.string.error_please_check_internet))
+                            }
+                            is TimeoutException -> {
+                                _message.postValue(MentorshipApplication.getContext()
+                                        .getString(R.string.error_request_timed_out))
+                            }
+                            is HttpException -> {
+                                _message.postValue(CommonUtils.getErrorResponse(error).message)
+                            }
+                            else -> {
+                                _message.postValue(MentorshipApplication.getContext()
+                                        .getString(R.string.error_something_went_wrong))
+                                        .also { Log.d(TAG, error.localizedMessage) }
+                            }
+                        }
+                    }
+
+                })
+                .addTo(compositeDisposable)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.dispose()
+    }
+}
+

--- a/app/src/main/res/layout/achievement_list_item.xml
+++ b/app/src/main/res/layout/achievement_list_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <android.support.v7.widget.AppCompatCheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:checked="true"
+        android:clickable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Sample Achievement"/>
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@+id/checkBox"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>
+

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,13 +1,193 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".view.fragments.HomeFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
+    <data>
+        <variable
+            name="stats"
+            type="org.systers.mentorship.models.HomeStatistics" />
+    </data>
+
+    <android.support.v4.widget.NestedScrollView
+        android:id="@+id/homeContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/fragment_title_home" />
+        android:fillViewport="true">
 
-</FrameLayout>
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:animateLayoutChanges="true"
+            tools:context=".view.fragments.HomeFragment">
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvWelcome"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:animateLayoutChanges="true"
+                android:text="@{stats != null ? (@string/welcome + `, ` + stats.name + `!`) : `Welcome!` }"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textSize="30sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Welcome, John" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvPendingRequests"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/pending_requests"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintStart_toStartOf="@+id/tvWelcome"
+                app:layout_constraintTop_toBottomOf="@+id/tvWelcome" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvAcceptedRequests"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/accepted_requests"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintStart_toStartOf="@+id/tvPendingRequests"
+                app:layout_constraintTop_toBottomOf="@+id/tvPendingRequests" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvRejectedRequests"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/rejected_requests"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintStart_toStartOf="@+id/tvAcceptedRequests"
+                app:layout_constraintTop_toBottomOf="@+id/tvAcceptedRequests" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvCompletedRelations"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/completed_relations"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintStart_toStartOf="@+id/tvRejectedRequests"
+                app:layout_constraintTop_toBottomOf="@+id/tvRejectedRequests" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvNumberOfPendingRequests"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@{stats != null ? String.valueOf(stats.pendingRequests) : String.valueOf(0)}"
+                android:textAlignment="textEnd"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tvPendingRequests"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/tvPendingRequests"
+                app:layout_constraintTop_toTopOf="@+id/tvPendingRequests"
+                tools:text="2" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvNumberOfAcceptedRequests"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@{stats != null ? String.valueOf(stats.acceptedRequests) : String.valueOf(0)}"
+                android:textAlignment="textEnd"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tvAcceptedRequests"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/tvAcceptedRequests"
+                app:layout_constraintTop_toTopOf="@+id/tvAcceptedRequests"
+                tools:text="1" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvNumberOfRejectedRequests"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@{stats != null ? String.valueOf(stats.rejectedRequests) : String.valueOf(0)}"
+                android:textAlignment="textEnd"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tvRejectedRequests"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/tvRejectedRequests"
+                app:layout_constraintTop_toTopOf="@+id/tvRejectedRequests"
+                tools:text="0" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvNumberOfCompletedRelations"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@{stats != null ? String.valueOf(stats.completedRelations) : String.valueOf(0)}"
+                android:textAlignment="textEnd"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tvCompletedRelations"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="1.0"
+                app:layout_constraintStart_toEndOf="@+id/tvCompletedRelations"
+                app:layout_constraintTop_toTopOf="@+id/tvCompletedRelations"
+                tools:text="1" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvRecentAchievementsTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/recent_achievements"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:textSize="24sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvCompletedRelations" />
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/rvAchievements"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:visibility="visible"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvRecentAchievementsTitle" />
+
+            <android.support.v7.widget.AppCompatTextView
+                android:id="@+id/tvNoAchievements"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="8dp"
+                android:text="@string/no_recent_achievements"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvRecentAchievementsTitle" />
+
+        </android.support.constraint.ConstraintLayout>
+    </android.support.v4.widget.NestedScrollView>
+</layout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,13 @@
     <string name="details">Details</string>
     <string name="tasks">Tasks</string>
     <string name="add_new_task">Add a new task</string>
+    <string name="pending_requests">Pending Requests</string>
+    <string name="accepted_requests">Accepted Requests</string>
+    <string name="rejected_requests">Rejected Requests</string>
+    <string name="completed_relations">Completed Relations</string>
+    <string name="welcome">Welcome</string>
+    <string name="no_recent_achievements">No recent achievements</string>
+    <string name="recent_achievements">Recent Achievements</string>
     <string name="confirm_logout">Confirm logout</string>
     <string name="confirm_logout_msg">Are you sure you want to logout?</string>
     <string name="logout">Logout</string>


### PR DESCRIPTION
Fixes issue systers#20. This adds user stats to the home screen
containing numbers for relations/requests, and the most recent
achievements.

### Description
Using the new /home endpoint on the backend, this PR adds user statistics to the home fragment.
It displays the count of various types of relations/requests, as well as recent achievements.

Fixes #20 

I have used the SingleLiveEvent class in this PR to show snackbars on the screen in case of an error. I picked this approach because of the following reasons:
1. Exposing the snackbar messages as an Observable is a clean way of separating responsibilites between the viewmodel and the view.
2. The SingleLiveEvent class ensures that the snackbar message is shown only once. If a regular LiveData object were used here, then the view would be notified of the latest value in the message observable on every configuration change. So if the user receives a snackbar message, they would receive it again if they rotate the scren.

Here's a demonstration of the SingleLiveEvent class in action: 
![Demonstration](https://user-images.githubusercontent.com/24315306/52612721-ee618100-2eb0-11e9-95e5-a70dd32df1b9.gif)

As you can see in the gif, the homescreen uses the SingleLiveEvent class to display Snackbars and therefore it is not shown again on configuration change, whereas the Profile Fragment does not use SLE and therefore its Snackbars are shown again on config change.

I have translated the SingleLiveEvent [source](https://github.com/googlesamples/android-architecture/blob/dev-todo-mvvm-live/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/SingleLiveEvent.java) from Java to Kotlin in order to maintain a 100% Kotlin codebase :)

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested on physical device and emulator.

<img src="https://user-images.githubusercontent.com/24315306/50726949-06b7e080-113a-11e9-9dd6-ff1d2929b2eb.jpeg" width="45%"></img> <img src="https://user-images.githubusercontent.com/24315306/50726950-091a3a80-113a-11e9-8159-3b7d7f00c471.jpeg" width="45%"></img> 


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes