### PR TITLE
feat : Added Logout confirmation dialog

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
@@ -1,8 +1,8 @@
 package org.systers.mentorship.view.activities
 
 import android.content.Intent
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AlertDialog
 import kotlinx.android.synthetic.main.activity_settings.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.PreferenceManager
@@ -20,9 +20,19 @@ class SettingsActivity : BaseActivity() {
         supportActionBar?.setDisplayShowHomeEnabled(true);
 
         tvLogout.setOnClickListener {
-            preferenceManager.clear()
-            startActivity(Intent(this, LoginActivity::class.java))
-            finishAffinity()
+            val builder = AlertDialog.Builder(this)
+            builder.setTitle(R.string.confirm_logout)
+            builder.setMessage(R.string.confirm_logout_msg)
+            builder.setPositiveButton(R.string.logout) { _, _ ->
+                preferenceManager.clear()
+                startActivity(Intent(this, LoginActivity::class.java))
+                finishAffinity()
+            }
+            builder.setNegativeButton(R.string.cancel) {dialog, _ ->
+                dialog.cancel()
+            }
+            val dialog: AlertDialog = builder.create()
+            dialog.show()
         }
     }
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,4 +107,7 @@
     <string name="details">Details</string>
     <string name="tasks">Tasks</string>
     <string name="add_new_task">Add a new task</string>
+    <string name="confirm_logout">Confirm logout</string>
+    <string name="confirm_logout_msg">Are you sure you want to logout?</string>
+    <string name="logout">Logout</string>
 </resources>


### PR DESCRIPTION
##  Description
Earlier , when the logout button was clicked , it immediately logged me out and sent me back to the main(login screen ) .
Now , on clicking the logout button a confirmation dialogue pops-up first (with two options - Cancel/Logout ) giving the user time to re-think if he/she really wants to logout.

Fixes #103 

**Type of Change:**
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

## How Has This Been Tested?

Tested on my Android device and verified that the feature is working fine

![updated](https://user-images.githubusercontent.com/43693949/51440407-bec5bb80-1cec-11e9-8aee-d397974a038e.gif)

## Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes