### PR TITLE
Fixes #138: Add Reporting Guidelines file into .github folder

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ Anyone asked to stop unacceptable behavior is expected to comply immediately.
 If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
 
 ## 6. Reporting Guidelines
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible by emailing systers.keeper@gmail.com. Please read [Reporting Guidelines](reporting_guidelines.md) for details.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible by emailing systers.keeper@gmail.com. Please read [Reporting Guidelines](REPORTING_GUIDELINES.md) for details.
 
 
 

--- a/.github/REPORTING_GUIDELINES.md
+++ b/.github/REPORTING_GUIDELINES.md
@@ -1,0 +1,53 @@
+# Reporting Guidelines
+
+If you believe someone is violating the code of conduct we ask that you report it to Systers by emailing systers.keeper@gmail.com. 
+
+**All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+If you believe anyone is in physical danger, please notify appropriate emergency services first. If you are unsure what service or agency is appropriate to contact, include this in your report and we will attempt to notify them.
+
+In your report please include:
+
+* Your contact info for follow-up contact.
+* Names (legal, nicknames, or pseudonyms) of any individuals involved.
+  * If there were other witnesses besides you, please try to include them as well.
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. 
+  * If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link.
+* Any extra context you believe existed for the incident.
+* If you believe this incident is ongoing.
+* Any other information you believe we should have.
+
+## What happens after you file a report?
+
+You will receive an email from the Systers's Code of Conduct response team acknowledging receipt as soon as possible, but within 24 hours.
+
+The working group will immediately meet to review the incident and determine:
+
+* What happened.
+* Whether this event constitutes a code of conduct violation.
+* What kind of response is appropriate.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the team's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once the team has a complete account of the events they will make a decision as to how to respond. Responses may include:
+
+* Nothing (if we determine no code of conduct violation occurred).
+* A private reprimand from the Code of Conduct response team to the individual(s) involved.
+* A public reprimand.
+* An imposed vacation (i.e. asking someone to "take a week off" from a mailing list or IRC).
+* A permanent or temporary ban from some or all of Systers spaces (events, meetings, mailing lists, IRC, etc.)
+* A request to engage in mediation and/or an accountability plan.
+
+We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original reporter to let them know what action (if any) we'll be taking. We'll take into account feedback from the reporter on the appropriateness of our response, but our response will be determined by what will be best for community safety.
+
+Finally, the response team will make a report on the situation to the Systers' Open Source Board. The board may choose to issue a public report of the incident or take additional actions.
+
+## Appealing the response
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision of the working group, contact the Systers' Open Source Board at techprogs@anitab.org with your appeal and the board will review the case.
+
+_Revision 1.0, DRAFT, proposed June 2014_
+_Reporting Guidelines derived from those of the [Django Software Foundation](https://www.djangoproject.com/conduct/reporting/)._


### PR DESCRIPTION
### Description
As a contributor,
I need reporting guidelines on the repository,
so that I can learn about the reporting guidelines if someone violates the code of conduct.

Fixes #138 

### Type of Change:
I have followed the steps mentioned in the issue #138 and applied the changes as mentioned.

- Documentation

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules