### PR TITLE
Fixed Members List lack of empty state

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.support.v7.widget.LinearLayoutManager
+import android.view.View
 import kotlinx.android.synthetic.main.fragment_members.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.Constants
@@ -39,15 +40,19 @@ class MembersFragment: BaseFragment() {
             (activity as MainActivity).hideProgressDialog()
             if (successful != null) {
                 if (successful) {
-
-                    rvMembers.apply {
-                        layoutManager = LinearLayoutManager(context)
-                        adapter = MembersAdapter(membersViewModel.userList, openUserProfile)
+                    if (membersViewModel.userList.isEmpty()) {
+                        tvEmptyList.text = getString(R.string.empty_members_list)
+                        rvMembers.visibility = View.GONE
+                    } else {
+                        rvMembers.apply {
+                            layoutManager = LinearLayoutManager(context)
+                            adapter = MembersAdapter(membersViewModel.userList, openUserProfile)
+                        }
+                        tvEmptyList.visibility = View.GONE
                     }
                 } else {
                     view?.let {
                         Snackbar.make(it, membersViewModel.message, Snackbar.LENGTH_LONG).show()
-
                     }
                 }
             }

--- a/app/src/main/res/layout/fragment_members.xml
+++ b/app/src/main/res/layout/fragment_members.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/rvMembers"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
+
+    <android.support.v7.widget.AppCompatTextView
+        android:id="@+id/tvEmptyList"
+        android:layout_width="250dp"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,5 @@
     <string name="confirm_logout">Confirm logout</string>
     <string name="confirm_logout_msg">Are you sure you want to logout?</string>
     <string name="logout">Logout</string>
+    <string name="empty_members_list">There are no other members.</string>
 </resources>


### PR DESCRIPTION
### Description
Added a message when there are no users for a nice user experience in the Members Screen. It shows a message when the Members List is empty.

Fixes #89 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix 

### How has this been tested?
On local device:
![image](https://user-images.githubusercontent.com/29125486/52250295-269b1980-291d-11e9-943d-03f9925d7173.png)
 

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] New and existing unit tests pass locally with my changes