### PR TITLE
fix: Checking network connection before opening member profile

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.systers.mentorship">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
@@ -1,10 +1,14 @@
 package org.systers.mentorship.view.adapters
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
 import androidx.annotation.NonNull
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.list_member_item.view.*
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
@@ -42,7 +46,14 @@ class MembersAdapter (
         val keyValueText = "$keyText: $validText"
         itemView.tvInterests.text = keyValueText
 
-        itemView.setOnClickListener { openDetailFunction(item.id!!) }
+        itemView.setOnClickListener {
+            if (isNetworkAvailable()) {
+            openDetailFunction(item.id!!)
+            } else {
+            Snackbar.make(holder.itemView, context.getString(R.string.error_please_check_internet), Snackbar.LENGTH_LONG)
+                    .show()
+            }
+        }
     }
 
     override fun getItemCount(): Int = userList.size
@@ -63,5 +74,13 @@ class MembersAdapter (
         }
 
         return context.getString(R.string.not_available_to_mentor_or_mentee)
+    }
+
+    private fun isNetworkAvailable(): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE)
+        return if (connectivityManager is ConnectivityManager) {
+            val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
+            networkInfo?.isConnected ?: false
+        } else false
     }
 }


### PR DESCRIPTION
### Description
Checking network connection before opening member profile in member fragment screen.

Fixes #195 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Perform manual testing.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
