### PR TITLE
fix: Fix travis built apk crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - build-tools-28.0.3
     - android-28
 before_install:
- - yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-27"
+ - yes | ${ANDROID_HOME}/tools/bin/sdkmanager "platforms;android-28"
 before_script:
  - chmod +x gradlew
  - chmod +x generate-apks.sh

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -12,7 +12,7 @@ object Versions {
     const val kotlinVersion = "1.3.21"
     const val supportLib = "1.0.0"
     const val designSupportLib = "1.0.0"
-    const val constraintLayout = "1.1.2"
+    const val constraintLayout = "1.1.3"
     const val junit = "4.12"
     const val testRunner = "1.1.0"
     const val espresso = "3.1.0"


### PR DESCRIPTION
### Description
Updated the constraint layout library version to fix the crash when launching the app through Travis built APK. Here's the solution I used: [Stackoverflow link](https://stackoverflow.com/questions/50783810/error-inflating-class-androidx-constraintlayout-widget-constraintlayout)

I have also updated the travis configuration file to use Android Pie build tools, so that it may not cause potential problems in the future.

Fixes #203 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Verified on my phone

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warning