### PR TITLE
Fix "Current Relation" empty state behaviour

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
@@ -58,7 +58,7 @@ class RelationPagerFragment : BaseFragment() {
             tvNoCurrentRelation.visibility = View.VISIBLE
             tlMentorshipRelation.visibility = View.GONE
             vpMentorshipRelation.visibility = View.GONE
-            tlMentorshipRelation.removeAllTabs()
+            baseActivity.tlMentorshipRelation.removeAllTabs()
         } else {
             tvNoCurrentRelation.visibility = View.GONE
             tlMentorshipRelation.visibility = View.VISIBLE

--- a/app/src/main/res/layout/fragment_relation_pager.xml
+++ b/app/src/main/res/layout/fragment_relation_pager.xml
@@ -116,18 +116,4 @@
         app:layout_constraintTop_toBottomOf="@+id/tvNotesLabel"
         app:layout_constraintVertical_bias="0.056" />
 
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/tvNoCurrentRelation"
-        android:layout_width="250dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/no_current_mentorship_relation"
-        android:textAlignment="center"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
removed duplicate fragment which was causing the error, remove tabs when there is no current relation

### Description
Small changes to fix the empty state behaviour. The message-fragment was included twice, which caused the error. I also removed the tabs when there is no relation. There are no dependencies that are required for this change.

Fixes #207 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- start with no current relation, then the empty state message should appear
- accept a relation request, then the relation details should appear and empty state message disappear
- cancel the relation, then the details should disappear, the tabs should be hidden and the empty state message should be shown
see gif included
![fix-empty-state-behaviour](https://user-images.githubusercontent.com/5339211/55838701-9bf5b700-5b25-11e9-9568-949c499cc824.gif)

### Checklist:
- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes