### PR TITLE
Fix login EditText misalignment in landscape mode

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -28,12 +28,11 @@
         android:layout_height="91dp"
         android:layout_marginBottom="256dp"
         android:layout_marginEnd="8dp"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:hint="@string/username_or_email"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.455"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/imageViewLogo">
 
@@ -58,7 +57,6 @@
         app:passwordToggleEnabled="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.505"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tiUsername"
         app:layout_constraintVertical_bias="0.098">
@@ -81,7 +79,6 @@
         android:layout_marginEnd="8dp"
         android:text="@string/login"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.505"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tiPassword" />
 


### PR DESCRIPTION
### Description
The activity had the EditText aligned in portrait mode in a pretty 'hacky' way, that does not work if the orientation is landscape. I've removed the horizontal bias settings in all of the inputs (username, password) and buttons (login and sign up), restoring it to the defaults and changed the unsymmetrical margin on the username input.

Fixes #177

### Type of Change:
- User Interface

### How Has This Been Tested?
The Design tab of Android Studio, and running it on my mobile device.

#### Portrait:
<img src="https://user-images.githubusercontent.com/18738527/58042345-14ee2280-7b58-11e9-86a4-f19b282532e6.png" width="240">

#### Landscape:
<img src="https://user-images.githubusercontent.com/18738527/58042479-6dbdbb00-7b58-11e9-9374-d86f2bdc1b2e.png" width="480">

Do note that the issue has been fixed (the alignment of the items). The issue of overlap is not created by this commit and is entirely another issue.
### Checklist:

- [x] My PR follows the style guidelines of this project