### PR TITLE
feat: Add delete mentorship task option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation Dependencies.design
     implementation Dependencies.constraint_layout
     implementation Dependencies.appCompat
+    implementation Dependencies.swipe_layout
     kapt Dependencies.databinding
     testImplementation Dependencies.junit
     androidTestImplementation Dependencies.test_runner

--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/TaskDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/TaskDataManager.kt
@@ -17,8 +17,16 @@ class TaskDataManager {
      * @param relationId mentorship relation id
      * @return an Observable of [CustomResponse]
      */
-    fun getAllTasks(relationId: Int): Observable<List<Task>> {
+    fun getAllTasks(relationId: Int): Observable<MutableList<Task>> {
         return apiManager.taskService.getAllTasksFromMentorshipRelation(relationId)
+    }
+
+    /**
+     * This will call a method from RelationService interface to delete a mentorship relation task
+     * @return an Observable of [CustomResponse]
+     */
+    fun deleteRelationshipTask(relationId: Int, taskId: Int): Observable<CustomResponse> {
+        return apiManager.taskService.deleteRelationshipTask(relationId, taskId)
     }
 
 }

--- a/app/src/main/java/org/systers/mentorship/remote/services/TaskService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/TaskService.kt
@@ -2,6 +2,7 @@ package org.systers.mentorship.remote.services
 
 import io.reactivex.Observable
 import org.systers.mentorship.models.Task
+import org.systers.mentorship.remote.responses.CustomResponse
 import retrofit2.http.*
 
 /**
@@ -15,5 +16,13 @@ interface TaskService {
      * @return an observable instance of a list of [Task]s
      */
     @GET("mentorship_relation/{relation_id}/tasks")
-    fun getAllTasksFromMentorshipRelation(@Path("relation_id") relationId: Int): Observable<List<Task>>
+    fun getAllTasksFromMentorshipRelation(@Path("relation_id") relationId: Int): Observable<MutableList<Task>>
+
+
+    /**
+     * This function deletes a mentorship relation task
+     * @return an observable instance of [CustomResponse] with a proper error or success message
+     */
+    @DELETE("mentorship_relation/{relation_id}/task/{task_id}")
+    fun deleteRelationshipTask(@Path("relation_id") relationId: Int, @Path("task_id") taskId: Int): Observable<CustomResponse>
 }

--- a/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
@@ -11,12 +11,13 @@ import org.systers.mentorship.models.Task
 
 /**
  * This class represents the adapter that fills in each view of the Tasks recyclerView
- * @param taskstsList list of tasks taken up by the mentee
+ * @param tasksList list of tasks taken up by the mentee
  * @param markTask function to be called when an item from Tasks list is clicked
  */
 class TasksAdapter(
         private val tasksList: List<Task>,
-        private val markTask: (taskId: Int) -> Unit
+        private val markTask: (taskId: Int) -> Unit,
+        private val deleteTask: (taskId: Int) -> Unit
 ) : RecyclerView.Adapter<TasksAdapter.TaskViewHolder>() {
 
     val context = MentorshipApplication.getContext();
@@ -31,7 +32,9 @@ class TasksAdapter(
         val itemView = holder.itemView
 
         itemView.cbTask.text = item.description
-        itemView.setOnClickListener { markTask(position) }
+        itemView.setOnClickListener { markTask(item.id) }
+
+        itemView.deleteTask.setOnClickListener { deleteTask(item.id) }
     }
 
     override fun getItemCount(): Int = tasksList.size

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -53,7 +53,7 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
                     } else {
                         rvTasks.apply {
                             layoutManager = LinearLayoutManager(context)
-                            adapter = TasksAdapter(taskViewModel.tasksList, markTask)
+                            adapter = TasksAdapter(taskViewModel.tasksList, markTask, deleteTask)
                         }
                         tvNoTask.visibility = View.GONE
                     }
@@ -71,6 +71,20 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
 
         taskViewModel.getTasks(mentorshipRelation.id)
 
+        rvTasks.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = TasksAdapter(taskViewModel.tasksList, markTask, deleteTask)
+        }
+
+        taskViewModel.successful.observe(this, Observer { successful ->
+            if(successful) {
+                rvTasks.adapter?.notifyDataSetChanged()
+            } else {
+                view?.let {
+                    Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
+                }
+            }
+        })
     }
 
     /**
@@ -93,8 +107,28 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
         builder.show()
     }
 
+    /**
+     * The function creates a dialog box to confirm if user wants to delete the task
+     */
+    fun showDeleteDialog(taskId: Int) {
+        val builder = AlertDialog.Builder(context)
+        builder.setTitle(appContext.getString(R.string.delete_task))
+        builder.setMessage(appContext.getString(R.string.delete_task_message))
+        builder.setPositiveButton(appContext.getString(R.string.yes)) { dialogInterface, i ->
+            taskViewModel.deleteTask(mentorshipRelation.id, taskId)
+        }
+        builder.setNegativeButton(appContext.getString(R.string.no)) { dialogInterface, i ->
+            dialogInterface.dismiss()
+        }
+        builder.show()
+    }
+
     private val markTask: (Int) -> Unit = { taskId ->
         cbTask.isChecked
         taskViewModel.updateTask(taskId, cbTask.isChecked)
+    }
+
+    private val deleteTask: (Int) -> Unit = { taskId ->
+        showDeleteDialog(taskId)
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
@@ -11,6 +11,7 @@ import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Task
 import org.systers.mentorship.remote.datamanager.TaskDataManager
+import org.systers.mentorship.remote.responses.CustomResponse
 import org.systers.mentorship.utils.CommonUtils
 import retrofit2.HttpException
 import java.io.IOException
@@ -23,7 +24,7 @@ class TasksViewModel: ViewModel() {
 
     var TAG = TasksViewModel::class.java.simpleName
 
-    lateinit var tasksList: List<Task>
+    var tasksList = mutableListOf<Task>()
 
     private val taskDataManager: TaskDataManager = TaskDataManager()
     val successful: MutableLiveData<Boolean> = MutableLiveData()
@@ -37,8 +38,8 @@ class TasksViewModel: ViewModel() {
         taskDataManager.getAllTasks(relationId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<List<Task>>() {
-                    override fun onNext(taskListResponse: List<Task>) {
+                .subscribeWith(object : DisposableObserver<MutableList<Task>>() {
+                    override fun onNext(taskListResponse: MutableList<Task>) {
                         tasksList = taskListResponse
                         successful.value = true
                     }
@@ -92,5 +93,62 @@ class TasksViewModel: ViewModel() {
             //completedTaskList.remove(taskList.get(taskId))
             //TODO: Update the backend
         }
+    }
+
+    /**
+     * This function helps in deleting tasks
+     * @param relationId
+     * @param taskId id of the task to be deleted
+     */
+    @SuppressLint("CheckResult")
+    fun deleteTask(relationId: Int, taskId: Int) {
+        taskDataManager.deleteRelationshipTask(relationId, taskId)
+                .subscribeOn(Schedulers.newThread())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeWith(object : DisposableObserver<CustomResponse>() {
+                    override fun onNext(customResponse: CustomResponse) {
+                        message = customResponse.message
+                        successful.value = true
+                        val taskToBeDeleted = getTaskFromId(taskId)
+                        tasksList.remove(taskToBeDeleted)
+                    }
+
+                    override fun onError(throwable: Throwable) {
+                        when (throwable) {
+                            is IOException -> {
+                                message = MentorshipApplication.getContext()
+                                        .getString(R.string.error_please_check_internet)
+                            }
+                            is TimeoutException -> {
+                                message = MentorshipApplication.getContext()
+                                        .getString(R.string.error_request_timed_out)
+                            }
+                            is HttpException -> {
+                                message = CommonUtils.getErrorResponse(throwable).message
+                            }
+                            else -> {
+                                message = MentorshipApplication.getContext()
+                                        .getString(R.string.error_something_went_wrong)
+                                Log.e(TAG, throwable.localizedMessage)
+                            }
+                        }
+                        successful.value = false
+                    }
+
+                    override fun onComplete() {
+                    }
+                })
+    }
+
+    /**
+     * This function helps in getting the Task object from it's id
+     * @param taskId id of the task whose object is to be returned
+     */
+    private fun getTaskFromId(taskId: Int): Task {
+        var task = Task(-1, "", false, 0f, 0f)
+        for (t: Task in tasksList)
+            if (t.id == taskId)
+                task = t
+        return task
     }
 }

--- a/app/src/main/res/layout/task_list_item.xml
+++ b/app/src/main/res/layout/task_list_item.xml
@@ -1,17 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.daimajia.swipe.SwipeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
 
-    <CheckBox
-        android:id="@+id/cbTask"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:text="CheckBox"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="50dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end|center_vertical">
+
+        <ImageView
+            android:id="@+id/deleteTask"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:drawable/list_selector_background"
+            android:tint="@android:color/holo_red_dark"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_delete_black_24dp"
+            android:contentDescription="@string/delete_task" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <CheckBox
+            android:id="@+id/cbTask"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="CheckBox"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.daimajia.swipe.SwipeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,8 @@
     <string name="details">Details</string>
     <string name="tasks">Tasks</string>
     <string name="add_new_task">Add a new task</string>
+    <string name="delete_task">Delete task</string>
+    <string name="delete_task_message">Are you sure you want to delete this task?</string>
     <string name="fetching_current_relation">Fetching Current Relation information…</string>
     <string name="pending_requests">Pending Requests</string>
     <string name="accepted_requests">Accepted Requests</string>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val testRule = "1.1.0"
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
-
+    const val swipeLayout = "1.2.0"
 }
 
 /**
@@ -53,4 +53,5 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+    const val swipe_layout = "com.daimajia.swipelayout:library:${Versions.swipeLayout}@aar"
 }


### PR DESCRIPTION
### Description
I've implemented the delete mentorship task option. Note that this changes the way tasks get added to `taskList` and `completedTaskList`. Instead of being a list of String, it is now a list of the Task object. This is done so that the particular `taskId` of each task is saved in each item of the RecyclerView, as the array index is not always the same as the `taskId`. I have also added 3 temporary tasks, that will be deleted if the delete button is pressed. The tasks are removed from the list after deletion, but will appear again if application is restarted (since we are giving static default temp tasks). However, now the delete option won't work since the tasks are already deleted.

Fixes #212

### Type of Change:

- Code
- User Interface

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Ran the tests on my phone, works as expected
<img src="https://user-images.githubusercontent.com/18738527/59135291-05fed100-899c-11e9-9030-7403b74bb771.png" width="200">
<img src="https://user-images.githubusercontent.com/18738527/59135299-1020cf80-899c-11e9-8101-6f349ca2e676.png" width="200">


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have written Kotlin Docs whenever is applicable


- [x] My changes generate no new warnings