### PR TITLE
Change title of About page to show user is in the About

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
@@ -14,6 +14,8 @@ class AboutActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_about)
 
+        supportActionBar?.title = getString(R.string.popup_menu_about)
+
         btnGit.setOnClickListener {
 
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_github))))


### PR DESCRIPTION
### Description
Added `supportActionBar` title. Getting it from the `strings` folder

Fixes [#226 ]

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
![mentorship_about_title](https://user-images.githubusercontent.com/42608330/60912911-a296e600-a25c-11e9-8026-d5a7cb30d679.png)

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials