### PR TITLE
fix: Enable cleartext support in debug mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            manifestPlaceholders = [usesCleartextTraffic:"false"]
+        }
+        debug {
+            manifestPlaceholders = [usesCleartextTraffic:"true"]
         }
     }
     dataBinding {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:theme="@style/AppTheme">
         <activity android:name=".view.activities.AboutActivity"></activity>
         <activity


### PR DESCRIPTION
### Description
On Android 9 and above, the app shows internet connection error even when the internet is available.

From [Network security configuration](https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted):
> Starting with Android 9 (API level 28), cleartext support is disabled by default.

Since our development server is HTTP, I've enabled support for cleartext in debug mode.
The production server will support HTTPS so we don't need cleartext in release mode.

Found the solution here: https://stackoverflow.com/a/53732801/6912045

Fixes #156 

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Tested on my Android 9 device.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings