### PR TITLE
fixes:In request detail page,When orientation is changed,notes and status of request are not entirely appearing according to the screen size of the device

### DIFF
--- a/app/src/main/res/layout/activity_request_detail.xml
+++ b/app/src/main/res/layout/activity_request_detail.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_parent">
 <androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_request_detail.xml
+++ b/app/src/main/res/layout/activity_request_detail.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvOtherUserName"
@@ -133,5 +137,5 @@
         app:layout_constraintTop_toBottomOf="@+id/tvRequestNotes"
         app:layout_constraintVertical_bias="0.092"
         tools:text="TextView" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
### Description
In request detail page,When orientation is changed, notes and status of request are not entirely appearing according to the screen size of the device.So I added scroll view to the activity_request_detail layout for proper appearance.

Fixes #188 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
After I made the changes, I tested it on my phone.
After changes:
![mobizen_20191125_222516](https://user-images.githubusercontent.com/43813438/69561788-ffa8f380-0fd3-11ea-949a-85ade204394f.gif)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules