### PR TITLE
[Program:GCI] fix: blank check on Notes field while sending mentorship request

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
@@ -98,7 +98,7 @@ class SendRequestActivity: BaseActivity() {
                 }
             }
 
-            if(!TextUtils.isEmpty(notes)) {
+            if(!TextUtils.isEmpty(notes.trim())) {
 
                 val sendRequestData = RelationshipRequest(
                         menteeId = menteeId,


### PR DESCRIPTION
### Description
Trims the notes field text before sending a request so that request notes can't be blank.

Fixes #251 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on my device.
![Record_2019-12-03-16-32-33_184af](https://user-images.githubusercontent.com/26629623/70046681-81a8a600-15ec-11ea-9999-eba135711ac5.gif)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings