### PR TITLE
[Program:GCI] Create an Alert Dialog for Delete Account option (Mentorship-Android)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,10 +21,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            manifestPlaceholders = [usesCleartextTraffic:"false"]
+            manifestPlaceholders = [usesCleartextTraffic: "false"]
         }
         debug {
-            manifestPlaceholders = [usesCleartextTraffic:"true"]
+            manifestPlaceholders = [usesCleartextTraffic: "true"]
         }
     }
     dataBinding {
@@ -48,6 +48,7 @@ dependencies {
     implementation Dependencies.design
     implementation Dependencies.constraint_layout
     implementation Dependencies.appCompat
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt Dependencies.databinding
     testImplementation Dependencies.junit
     androidTestImplementation Dependencies.test_runner

--- a/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
@@ -7,6 +7,7 @@ import kotlinx.android.synthetic.main.activity_settings.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.PreferenceManager
 import org.systers.mentorship.view.fragments.ChangePasswordFragment
+import org.systers.mentorship.view.fragments.DeleteAccountFragment
 
 class SettingsActivity : BaseActivity() {
 
@@ -41,6 +42,9 @@ class SettingsActivity : BaseActivity() {
         }
         tvAbout.setOnClickListener {
             startActivity(Intent(baseContext,AboutActivity::class.java))
+        }
+        tvDeleteAccount.setOnClickListener{
+            DeleteAccountFragment.newInstance().show(supportFragmentManager, null)
         }
     }
 

--- a/app/src/main/java/org/systers/mentorship/view/fragments/DeleteAccountFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/DeleteAccountFragment.kt
@@ -1,0 +1,83 @@
+package org.systers.mentorship.view.fragments
+
+
+import android.app.Dialog
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.util.Log
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import kotlinx.android.synthetic.main.fragment_delete_account.view.*
+
+import org.systers.mentorship.R
+
+/*
+* Author: Abhinav Srivastava
+* Display Name: asawesome7
+* email ID: abhinav.wii@gmail.com*/
+
+/**
+ * A simple [Fragment] subclass.
+ */
+class DeleteAccountFragment : DialogFragment() {
+
+    companion object {
+        /**
+         * Creates an instance of DeleteAccountFragment
+         */
+        fun newInstance() = DeleteAccountFragment()
+    }
+
+    private lateinit var deleteAccountView: View
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+
+        deleteAccountView = LayoutInflater.from(context).inflate(R.layout.fragment_delete_account, null)
+        val builder = AlertDialog.Builder(requireContext())
+        builder.setTitle(getString(R.string.settings_DeleteAccountTitle))
+        builder.setMessage(getString(R.string.settings_DeleteAccountMessage))
+        builder.setView(deleteAccountView)
+        builder.setPositiveButton(getString(R.string.settings_DeleteAccountDelete)) { dialog, _ ->
+            Toast.makeText(activity, "Account delete initiated", Toast.LENGTH_SHORT).show()
+            //put backend code for deletion
+        }
+        builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
+            dialog.cancel()
+        }
+        return builder.create()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val deleteAccountDialog = dialog as? AlertDialog
+        deleteAccountDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
+
+        deleteAccountView.settingsDeleteInp?.editText?.addTextChangedListener(
+                object : TextWatcher {
+                    override fun afterTextChanged(s: Editable?) {
+
+                    }
+
+                    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+                    }
+
+                    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                        deleteAccountDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = s.toString() == "DELETE"
+                    }
+
+                })
+
+    }
+
+
+
+}

--- a/app/src/main/res/layout/fragment_delete_account.xml
+++ b/app/src/main/res/layout/fragment_delete_account.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.fragments.DeleteAccountFragment">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/settingsDeleteInp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="DELETE"
+        android:paddingStart="20dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,10 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="settings_DeleteAccountDelete">Delete</string>
+    <string name="settings_DeleteAccountTitle">Confirm account deletion</string>
+    <string name="settings_DeleteAccountMessage">Please type in DELETE in the input field to confirm account deletion\n\nOnce the account has been deleted, it cannot be retained\n</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
### Description
Added an alert dialog box, when opened, prompts the user to type in DELETE in the input field before they can proceed to delete the account. This feature was added as a security feature to prevent accidental account deletion.

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I ran the app in an emulator and on my phone. Here are some screenshots

When the dialog box opens, the delete button is disabled
![Screenshot_1575319284](https://user-images.githubusercontent.com/29257061/70076315-8b4e0000-1624-11ea-8f67-93a36d223fac.png)

Then after typing in DELETE it is enabled giving the user the ability to delete the account
![Screenshot_1575319302](https://user-images.githubusercontent.com/29257061/70076386-ad478280-1624-11ea-9247-735d5cb100c4.png)

Once delete button has been clicked a toast pops up as confirmation
![Screenshot_1575319305](https://user-images.githubusercontent.com/29257061/70076430-c3554300-1624-11ea-83e9-ccbe1dea9342.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules