### PR TITLE
[Program:GCI] Create warning dialog boxes to accept and reject mentorship requests (Mentorship-Android)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,7 @@ dependencies {
 
     implementation Dependencies.lifecycle_extensions
     implementation Dependencies.lifecycle_viewmodel
+
+    api 'com.google.android.material:material:1.2.0-alpha02'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
             android:name=".view.activities.SignUpActivity"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity android:name=".view.activities.MainActivity" />
-        <activity android:name=".view.activities.RequestDetailActivity" />
+        <activity android:name=".view.activities.RequestDetailActivity"
+           android:theme="@style/RequestDetailActivityTheme" />
         <activity android:name=".view.activities.MemberProfileActivity" />
         <activity android:name=".view.activities.SendRequestActivity" />
         <activity android:name=".view.activities.SettingsActivity" />

--- a/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
@@ -1,5 +1,7 @@
 package org.systers.mentorship.view.activities
 
+import android.annotation.SuppressLint
+import android.app.AlertDialog
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
@@ -15,6 +17,10 @@ import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.utils.*
 import org.systers.mentorship.viewmodels.RequestDetailViewModel
 import android.content.Intent
+import android.content.res.Resources
+import android.view.LayoutInflater
+import androidx.core.content.ContextCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.systers.mentorship.view.fragments.RequestPagerFragment
 
 /**
@@ -121,6 +127,7 @@ class RequestDetailActivity: BaseActivity() {
         }
     }
 
+    @SuppressLint("ResourceAsColor")
     private fun setOnClickListeners(relationResponse: Relationship) {
 
         btnDelete.setOnClickListener {
@@ -128,11 +135,31 @@ class RequestDetailActivity: BaseActivity() {
         }
 
         btnReject.setOnClickListener {
-            requestDetailViewModel.rejectRequest(relationResponse.id)
+            val builder = MaterialAlertDialogBuilder(this, R.style.ThemeOverlay_MaterialComponents_MaterialAlertDialog_Centered)
+                    .setTitle(R.string.rda_rejecttitle)
+                    .setMessage(getString(R.string.rda_rejectmessage1) + relationResponse.mentor.name + getString(R.string.rda_rejectmessage2))
+                    .setPositiveButton(R.string.rda_reject){dialog, _ ->
+                        requestDetailViewModel.rejectRequest(relationResponse.id)
+                    }
+                    .setNegativeButton(R.string.rda_decide_later){dialog, _ ->
+                        dialog.cancel()
+                    }
+            val dialog : androidx.appcompat.app.AlertDialog = builder.create()
+            dialog.show()
         }
 
         btnAccept.setOnClickListener {
-            requestDetailViewModel.acceptRequest(relationResponse.id)
+            val builder = MaterialAlertDialogBuilder(this, R.style.ThemeOverlay_MaterialComponents_MaterialAlertDialog_Centered)
+                    .setTitle(R.string.rda_accepttitle)
+                    .setMessage(getString(R.string.rda_acceptmessage1) + relationResponse.mentor.name + getString(R.string.rda_acceptmessage2))
+                    .setPositiveButton(R.string.rda_accept){dialog, _ ->
+                        requestDetailViewModel.acceptRequest(relationResponse.id)
+                    }
+                    .setNegativeButton(R.string.rda_decide_later){dialog, _ ->
+                        dialog.cancel()
+                    }
+            val dialog : androidx.appcompat.app.AlertDialog = builder.create()
+            dialog.show()
         }
     }
 

--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -55,7 +55,7 @@ class EditProfileFragment: DialogFragment() {
                 }
             }
         })
-        dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        dialog?.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         isCancelable = false
         return inflater.inflate(R.layout.fragment_edit_profile, container, false)
     }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -63,7 +63,7 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
+                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager!!,
                         getString(R.string.fragment_title_edit_profile))
                 true
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,13 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="rda_accept">Accept</string>
+    <string name="rda_decide_later">Decide later</string>
+    <string name="rda_reject">Reject</string>
+    <string name="rda_acceptmessage1">Are you sure you want to make </string>
+    <string name="rda_acceptmessage2"> your mentor?</string>
+    <string name="rda_accepttitle">Confirm acceptance</string>
+    <string name="rda_rejectmessage1">Are you sure you want to reject </string>
+    <string name="rda_rejectmessage2"> as your mentor?</string>
+    <string name="rda_rejecttitle">Confirm rejection</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -12,4 +12,11 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
+    <style name="RequestDetailActivityTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Description
Added Accept and Reject dialog boxes that prompt user to confirm acceptance and rejection of mentorship relation.

NOTE: also fixed 2 errors that popped up in files app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt and
app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt

TASK: https://codein.withgoogle.com/tasks/4983979728437248/?sp-organization=5462163573964800&sp-is_beginner=False

Fixes #250 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

## How Has This Been Tested?
I ran the build on an emulator and on my phone. Here's a GIF

Notice how the mentor's name is mentioned in the dialog box
![untitled](https://user-images.githubusercontent.com/29257061/70185329-916cdb00-170f-11ea-93bb-495fca2d4c02.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules