### PR TITLE
[Program:GCI] Show SnackBar when both users are 'only available to mentor'

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -49,10 +49,16 @@ class MemberProfileActivity : BaseActivity() {
         memberProfileViewModel.getUserProfile(userId)
 
         btnSendRequest.setOnClickListener {
-            val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
-            intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
-            intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
-            startActivity(intent)
+            if(memberProfileViewModel.userProfile?.isAvailableToMentor ?: false && !(memberProfileViewModel.userProfile?.needsMentoring ?:false)
+                    && (userProfile?.isAvailableToMentor ?: false && !(userProfile?.needsMentoring ?:false))){
+                Snackbar.make(getRootView(), getString(R.string.both_users_only_available_to_mentor), Snackbar.LENGTH_LONG)
+                        .show()
+            } else{
+                val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
+                intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
+                intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
+                startActivity(intent)
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="only_available_to_mentor">Only available to mentor</string>
     <string name="only_available_to_mentee">Only available to be a mentee</string>
     <string name="not_available_to_mentor_or_mentee">Not available to be a mentor or a mentee</string>
+    <string name="both_users_only_available_to_mentor">This request is not possible because both users are only ‘available to mentor\'</string>
     <string name="user_photo">User Photo</string>
     <string name="pending">Pending</string>
     <string name="past">Past</string>


### PR DESCRIPTION
### Description
When the current user and a selected user are both only "available to mentor", I have shown SnackBar in MemberProfileActivity that displays "This request is not possible because both users are only ‘available to mentor’" instead starting SendRequestActivity.

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested on an Android emulator. Here is a gif of the SnackBar showing when needed. 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/23027638/70259845-043a8c80-17ca-11ea-9ad7-d0bdf9b05dba.gif)

### Checklist:
- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

- [X] My changes generate no new warnings