### PR TITLE
[Program: GCI] feat: Integrate past mentorship relations from backend via API

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/RelationDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/RelationDataManager.kt
@@ -23,6 +23,15 @@ class RelationDataManager {
     }
 
     /**
+     * This will call a method of RelationService interface to fetch
+     * past mentorship requests and relations
+     * @return an Observable of a list of [Relationship]
+     */
+    fun getPastRelationships(): Observable<List<Relationship>> {
+        return apiManager.relationService.getPastRelationships()
+    }
+
+    /**
      * This will call a method from RelationService interface to accept a mentorship request
      * @param relationId id of the request being accepted
      * @return an Observable of [CustomResponse]

--- a/app/src/main/java/org/systers/mentorship/remote/services/RelationService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/RelationService.kt
@@ -19,6 +19,13 @@ interface RelationService {
     fun getAllRelationships(): Observable<List<Relationship>>
 
     /**
+     * This function returns past mentorship requests and relations of the current user
+     * @return an observable instance of a list of [Relationship]s
+     */
+    @GET("mentorship_relations/past")
+    fun getPastRelationships(): Observable<List<Relationship>>
+
+    /**
      * This function performs the acceptance of a mentorship request
      * @return an observable instance of [CustomResponse] with a proper error or success message
      */

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RequestsFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RequestsFragment.kt
@@ -52,5 +52,6 @@ class RequestsFragment : BaseFragment() {
 
         activityCast.showProgressDialog(getString(R.string.fetching_requests))
         requestsViewModel.getAllMentorshipRelations()
+        requestsViewModel.getPastMentorshipRelations()
     }
 }


### PR DESCRIPTION
### Description
Integrate past mentorship relations from backend via API. 

#### Working
1. *RelationshipService.kt* makes API call to mentorship_relations/past
2. **getPastRelationships()** in *RelationDataManager.kt* reads this as ``` Observable <List<Relationship>>```
3. **getPastMentorshipRelations()** in *RequestsViewModel.kt* subscribes to the data and manages exception handling
4. **getPastMentorshipRelations()** called in *RequestsFragment.kt*. It displays this data in *fragment_requests.xml*

### Type of Change:
- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Backdating mentorship requests was not possible. So following method was used:
1. Run mentorship-backend locally. Add http://10.0.2.2:5000/ in app in place of original URL in **BaseUrl.kt**. This is the special port address for Android emulators. *This code is not included in commit.*
```java
    val apiBaseUrl: String
        get() = if (BuildConfig.DEBUG) {
            "http://10.0.2.2:5000/"
            //"$PROTOCOL_HTTPS$DEVELOPMENT_URL$EB_REGION"
        } else {
            "$PROTOCOL_HTTPS$PRODUCTION_URL$EB_REGION"
        }
```
2. To backdate requests the computer's time was changed
![task11_1](https://user-images.githubusercontent.com/50169911/70318227-8f0c9d00-1845-11ea-9813-4f59bc0ffe68.png)

3. Add dummy data to via POST to **mentorship_relation/send_request**
![task11_2](https://user-images.githubusercontent.com/50169911/70318250-a2b80380-1845-11ea-9cc6-61ad95273ce6.png)

4. Test in App
![task11_3](https://user-images.githubusercontent.com/50169911/70318425-0cd0a880-1846-11ea-81d4-bddac0488f61.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works