### PR TITLE
[Program: GCI] feat: Added, now request can't be send if both are mentors.

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -31,6 +31,28 @@ class MemberProfileActivity : BaseActivity() {
 
         val userId = intent.getIntExtra(Constants.MEMBER_USER_ID, 0)
 
+        /**
+         * Getting the current user profile here.
+         * */
+        lateinit var currUser:User
+        userProfileViewModel = ViewModelProviders.of(this).get(ProfileViewModel::class.java)
+        userProfileViewModel.successfulGet.observe(this, Observer {
+            successful ->
+            hideProgressDialog()
+            if (successful != null) {
+                if (successful) {
+                    currUser=userProfileViewModel.user
+                } else {
+                    Snackbar.make(getRootView(), userProfileViewModel.message, Snackbar.LENGTH_LONG)
+                            .show()
+                }
+            }
+        })
+        userProfileViewModel.getProfile()
+
+        /**
+         * Getting the member profile here
+         * */
         memberProfileViewModel = ViewModelProviders.of(this).get(MemberProfileViewModel::class.java)
         memberProfileViewModel.successful.observe(this, Observer {
             successful ->
@@ -52,7 +74,19 @@ class MemberProfileActivity : BaseActivity() {
             val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
             intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
             intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
-            startActivity(intent)
+
+            /**
+             * If another user is available as a mentor and not as a mentee and,
+             * current user is also available only as a mentor then,
+             * request can't be send
+             * */
+            if ((userProfile.isAvailableToMentor!! && !userProfile.needsMentoring!!) &&
+                    (currUser.isAvailableToMentor!! && !currUser.needsMentoring!!)  ){
+                Snackbar.make(getRootView(), R.string.invalidRequest, Snackbar.LENGTH_LONG)
+                        .show()
+            }else{
+                startActivity(intent)
+            }
         }
     }
 


### PR DESCRIPTION

### Description
Added  that : When both current and the other user are only available as mentors, then the request cannot be sent.


Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested by me on my personal device. Have also attached Screenshot and GIF.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ 
![Screenshot_2019-12-08-13-16-10-06_184af3f6adcdf091d91f35c3acb0ce61](https://user-images.githubusercontent.com/58501114/70386552-92c42f00-19bf-11ea-9900-174d70eb72c1.png)
![20191208_131826](https://user-images.githubusercontent.com/58501114/70386557-9ce62d80-19bf-11ea-9e12-ca19886bb336.gif)


] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules