### PR TITLE
[Program:GCI] All tabs get updated when existing request is deleted

### DIFF
--- a/app/src/main/java/org/systers/mentorship/utils/Constants.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Constants.kt
@@ -9,4 +9,6 @@ object Constants {
     const val RELATIONSHIP_EXTRA = "relationship_extra"
     const val DELETE_REQUEST_RESULT_ID = 1000
     const val REQUEST_ID = "request_id"
+    const val SHARED_PREFERENCE_NAME="org.systers.mentorship.utils"
+    const val SHARED_PREFERENCE_KEY="DELETED_REQUESTS_SET"
 }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RequestPagerFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RequestPagerFragment.kt
@@ -1,6 +1,8 @@
 package org.systers.mentorship.view.fragments
 
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
@@ -36,13 +38,23 @@ class RequestPagerFragment: BaseFragment() {
     private lateinit var requestsList: MutableList<Relationship>
     private lateinit var emptyListText: String
 
+    private lateinit var preferenceManager:SharedPreferences
+    private var deletedRequests: MutableSet<String>? = mutableSetOf()
+
     override fun getLayoutResourceId() = R.layout.fragment_request_pager
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        /**
+         * Using shared preferences to store the id(s) of deleted requests for reference
+         * */
+        preferenceManager= context!!.getSharedPreferences(Constants.SHARED_PREFERENCE_NAME,Context.MODE_PRIVATE)
+        preferenceManager?.edit()?.putStringSet(Constants.SHARED_PREFERENCE_KEY,deletedRequests)?.commit()
+        deletedRequests=preferenceManager.getStringSet(Constants.SHARED_PREFERENCE_KEY,null)
+
         arguments?.let {
-            requestsList = it.getParcelableArrayList(Constants.REQUEST_LIST)
+            requestsList = it.getParcelableArrayList(Constants.REQUEST_LIST)!!
             emptyListText = it.getString(Constants.REQUEST_EMPTY_LIST_TEXT)
         }
         setView()
@@ -57,28 +69,53 @@ class RequestPagerFragment: BaseFragment() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        val id = data?.getStringExtra(Constants.REQUEST_ID)
-        val iter = requestsList.iterator()
+        val id=data?.getStringExtra(Constants.REQUEST_ID)
 
-        while (iter.hasNext()) {
-            val reqId = iter.next().id
-            if(reqId.toString() == id) {
-                iter.remove()
-            }
-        }
+        /**
+         * Adding newly deleted requests to SharedPreference
+         * */
+        deletedRequests!!.add(id.toString())
+        preferenceManager?.edit()?.putStringSet(Constants.SHARED_PREFERENCE_KEY,deletedRequests)?.commit()
+
+        refreshList(deletedRequests!!)
         setView()
     }
-    
+
     private fun setView() {
+        /**
+         * Checking for any deleted requests
+         * */
+        if (deletedRequests!!.size>0){
+            refreshList(deletedRequests!!)
+        }
+
         if (requestsList.isEmpty()) {
             tvEmptyList.text = emptyListText
+            tvEmptyList.visibility = View.VISIBLE
             rvRequestsList.visibility = View.GONE
         } else {
             rvRequestsList.apply {
                 layoutManager = LinearLayoutManager(context)
                 adapter = RequestsAdapter(requestsList, openRequestDetail)
             }
+            RequestPagerFragment.newInstance(requestsList,"")
             tvEmptyList.visibility = View.GONE
+        }
+    }
+
+    /**
+     * This method removes the deleted requests from the main list of 'requestsList'
+     * by comparing the requests in the two sets with their id,
+     * and then the setView() method updates the current page with updated list.
+     * */
+    private fun refreshList(id: MutableSet<String>) {
+
+        val iter = requestsList.iterator()
+        while (iter.hasNext()) {
+            val reqId = iter.next().id
+            if(reqId.toString() in id) {
+                iter.remove()
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
.All tabs in the request pager fragment get updated when existing request is deleted.

Fixes # [ISSUE]

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
This feature has been tested by me on my personal device and GIF has been attached.


### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules

![20191210_095407](https://user-images.githubusercontent.com/58501114/70494950-2ec27780-1b33-11ea-91bf-0843a1296402.gif)

