### PR TITLE
[Program: GCI] feat: SearchView in MembersFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,6 @@ dependencies {
 
     implementation Dependencies.lifecycle_extensions
     implementation Dependencies.lifecycle_viewmodel
+
+    implementation Dependencies.material_search_view
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,10 @@
         <activity
             android:name=".view.activities.SignUpActivity"
             android:theme="@style/AppTheme.NoActionBar" />
-        <activity android:name=".view.activities.MainActivity" />
+        <activity
+            android:name=".view.activities.MainActivity"
+            android:theme="@style/AppTheme.NoActionBar"
+            android:windowSoftInputMode="adjustPan" />
         <activity android:name=".view.activities.RequestDetailActivity" />
         <activity android:name=".view.activities.MemberProfileActivity" />
         <activity android:name=".view.activities.SendRequestActivity" />

--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.view.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.PersistableBundle
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import android.view.Menu
 import android.view.MenuItem
@@ -14,7 +13,7 @@ import org.systers.mentorship.view.fragments.*
 /**
  * This activity has the bottom navigation which allows the user to switch between fragments
  */
-class MainActivity: BaseActivity() {
+class MainActivity : BaseActivity() {
 
     private var atHome = true
 
@@ -23,6 +22,9 @@ class MainActivity: BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // we need toolbar for search function to work properly
+        setSupportActionBar(findViewById(R.id.toolbar))
 
         bottomNavigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
 
@@ -35,40 +37,40 @@ class MainActivity: BaseActivity() {
 
     private val mOnNavigationItemSelectedListener =
             BottomNavigationView.OnNavigationItemSelectedListener { item ->
-        when (item.itemId) {
-            R.id.navigation_home -> {
-                replaceFragment(R.id.contentFrame, HomeFragment.newInstance(),
-                        R.string.fragment_title_home)
-                atHome = true
-                return@OnNavigationItemSelectedListener true
+                when (item.itemId) {
+                    R.id.navigation_home -> {
+                        replaceFragment(R.id.contentFrame, HomeFragment.newInstance(),
+                                R.string.fragment_title_home)
+                        atHome = true
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_profile -> {
+                        replaceFragment(R.id.contentFrame, ProfileFragment.newInstance(),
+                                R.string.fragment_title_profile)
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_relation -> {
+                        replaceFragment(R.id.contentFrame, RelationPagerFragment.newInstance(),
+                                R.string.fragment_title_relation)
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_members -> {
+                        replaceFragment(R.id.contentFrame, MembersFragment.newInstance(),
+                                R.string.fragment_title_members)
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_requests -> {
+                        replaceFragment(R.id.contentFrame, RequestsFragment.newInstance(),
+                                R.string.fragment_title_requests)
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                }
+                false
             }
-            R.id.navigation_profile -> {
-                replaceFragment(R.id.contentFrame, ProfileFragment.newInstance(),
-                        R.string.fragment_title_profile)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_relation -> {
-                replaceFragment(R.id.contentFrame, RelationPagerFragment.newInstance(),
-                        R.string.fragment_title_relation)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_members -> {
-                replaceFragment(R.id.contentFrame, MembersFragment.newInstance(),
-                        R.string.fragment_title_members)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_requests -> {
-                replaceFragment(R.id.contentFrame, RequestsFragment.newInstance(),
-                        R.string.fragment_title_requests)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-        }
-        false
-    }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.main_menu, menu)
@@ -97,10 +99,14 @@ class MainActivity: BaseActivity() {
     }
 
     override fun onBackPressed() {
-        if (!atHome) {
-            showHomeFragment()
+        if (search_view.isSearchOpen) {
+            search_view.closeSearch()
         } else {
-            super.onBackPressed()
+            if (!atHome) {
+                showHomeFragment()
+            } else {
+                super.onBackPressed()
+            }
         }
     }
 }

--- a/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
@@ -1,27 +1,34 @@
 package org.systers.mentorship.view.adapters
 
-import androidx.annotation.NonNull
-import androidx.recyclerview.widget.RecyclerView
+import android.graphics.Color
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.NonNull
+import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.list_member_item.view.*
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.utils.NON_VALID_VALUE_REPLACEMENT
+import java.util.*
 
 /**
  * This class represents the adapter that fills in each view of the Members recyclerView
  * @param userList list of users to show
  * @param openDetailFunction function to be called when an item from Members list is clicked
  */
-class MembersAdapter (
+class MembersAdapter(
         private val userList: List<User>,
         private val openDetailFunction: (memberId: Int) -> Unit
 ) : RecyclerView.Adapter<MembersAdapter.MembersViewHolder>() {
 
-    val context = MentorshipApplication.getContext()
+    private val filteredUserList = userList.toMutableList()
+    private val context = MentorshipApplication.getContext()
+    private var filter = ""
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MembersViewHolder =
             MembersViewHolder(
@@ -30,10 +37,21 @@ class MembersAdapter (
             )
 
     override fun onBindViewHolder(@NonNull holder: MembersViewHolder, position: Int) {
-        val item = userList[position]
+        val item = filteredUserList[position]
         val itemView = holder.itemView
 
-        itemView.tvName.text = item.name
+        // the beginning of  searchQuery  -> end = startIndex + length
+        val startIndex = item.name?.toLowerCase(Locale.getDefault())?.indexOf(filter) ?: 0
+        val spannableStringBuilder = SpannableStringBuilder(item.name ?: "")
+
+        // the text is already bold, so we just change color to the primary color
+        val foregroundColorSpan = ForegroundColorSpan(Color.rgb(137, 36, 104))
+
+        // change colors of characters
+        spannableStringBuilder.setSpan(foregroundColorSpan, startIndex, startIndex + filter.length,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE)
+
+        itemView.tvName.text = spannableStringBuilder
         itemView.tvMentorshipAvailability.text = getMentorshipAvailabilityText(item.isAvailableToMentor, item.needsMentoring)
 
         val userInterests = item.interests
@@ -45,7 +63,17 @@ class MembersAdapter (
         itemView.setOnClickListener { openDetailFunction(item.id!!) }
     }
 
-    override fun getItemCount(): Int = userList.size
+    override fun getItemCount(): Int = filteredUserList.size
+
+    fun filterByName(name: String) {
+        filter = name.toLowerCase(Locale.getDefault())
+        filteredUserList.clear()
+        filteredUserList.addAll(userList.filter {
+            it.name?.toLowerCase(Locale.getDefault())?.contains(
+                    name.toLowerCase(Locale.getDefault())) ?: name.isEmpty()
+        })
+        notifyDataSetChanged()
+    }
 
     /**
      * This class holds a view for each item of the Members list

--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -1,12 +1,15 @@
 package org.systers.mentorship.view.fragments
 
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
-import androidx.recyclerview.widget.LinearLayoutManager
+import android.view.Menu
+import android.view.MenuInflater
 import android.view.View
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.snackbar.Snackbar
+import com.miguelcatalan.materialsearchview.MaterialSearchView
 import kotlinx.android.synthetic.main.fragment_members.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.Constants
@@ -18,7 +21,7 @@ import org.systers.mentorship.viewmodels.MembersViewModel
 /**
  * The fragment is responsible for showing all the members of the system in a list format
  */
-class MembersFragment: BaseFragment() {
+class MembersFragment : BaseFragment() {
 
     companion object {
         /**
@@ -28,15 +31,40 @@ class MembersFragment: BaseFragment() {
     }
 
     private lateinit var membersViewModel: MembersViewModel
+    private lateinit var searchView: MaterialSearchView
+    private lateinit var membersAdapter: MembersAdapter
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_members
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        setHasOptionsMenu(true)
+        searchView = requireActivity().findViewById(R.id.search_view)
+
+        searchView.setOnQueryTextListener(object : MaterialSearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String): Boolean {
+                return false
+            }
+
+            override fun onQueryTextChange(newText: String): Boolean {
+                membersAdapter.filterByName(newText)
+
+                // if there are no elements show TextView and hide RecyclerView
+                if (membersAdapter.itemCount == 0) {
+                    rvMembers.visibility = View.GONE
+                    tv_no_results.visibility = View.VISIBLE
+                    tv_no_results.text = String.format(getString(R.string.no_results_found), newText)
+                } else {
+                    rvMembers.visibility = View.VISIBLE
+                    tv_no_results.visibility = View.GONE
+                }
+                return true
+            }
+        })
+
         membersViewModel = ViewModelProviders.of(this).get(MembersViewModel::class.java)
-        membersViewModel.successful.observe(this, Observer {
-            successful ->
+        membersViewModel.successful.observe(this, Observer { successful ->
             (activity as MainActivity).hideProgressDialog()
             if (successful != null) {
                 if (successful) {
@@ -46,7 +74,8 @@ class MembersFragment: BaseFragment() {
                     } else {
                         rvMembers.apply {
                             layoutManager = LinearLayoutManager(context)
-                            adapter = MembersAdapter(membersViewModel.userList, openUserProfile)
+                            membersAdapter = MembersAdapter(membersViewModel.userList, openUserProfile)
+                            adapter = membersAdapter
                         }
                         tvEmptyList.visibility = View.GONE
                     }
@@ -68,4 +97,11 @@ class MembersFragment: BaseFragment() {
                 intent.putExtra(Constants.MEMBER_USER_ID, memberId)
                 startActivity(intent)
             }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_members, menu)
+        searchView.setMenuItem(menu.findItem(R.id.search_member))
+    }
+
 }

--- a/app/src/main/res/drawable/ic_search_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_white_24dp.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15.5 14h-0.79l-0.28-0.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-0.59 4.23-1.57l 0.27 0.28v0.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+    <path android:pathData="M0 0h24v24H0z" />
+</vector>
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,24 @@
     android:layout_height="match_parent"
     tools:context=".view.activities.MainActivity">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/colorPrimary"
+        android:elevation="4dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:titleTextColor="@color/white"
+        tools:targetApi="lollipop" />
+
+    <com.miguelcatalan.materialsearchview.MaterialSearchView
+        android:id="@+id/search_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:elevation="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:targetApi="lollipop" />
+
     <FrameLayout
         android:id="@+id/contentFrame"
         android:layout_width="match_parent"
@@ -16,17 +34,17 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
         app:layout_constraintVertical_bias="1.0" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:labelVisibilityMode="labeled"
-        android:layout_marginEnd="0dp"
         android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/fragment_members.xml
+++ b/app/src/main/res/layout/fragment_members.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvMembers"
-        android:scrollbars="vertical"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="0dp"
-        android:layout_height="0dp" />
+        android:layout_height="0dp"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_no_results"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvEmptyList"
@@ -23,6 +33,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_members.xml
+++ b/app/src/main/res/menu/menu_members.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/search_member"
+        android:icon="@drawable/ic_search_white_24dp"
+        android:orderInCategory="100"
+        android:title="@string/search_member"
+        app:showAsAction="ifRoom|collapseActionView" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,6 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="search_member">Search member</string>
+    <string name="no_results_found">No results found for \'%s\'</string>
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val testRule = "1.1.0"
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
-
+    const val materialSearchView = "1.4.0"
 }
 
 /**
@@ -53,4 +53,5 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+    const val material_search_view = "com.miguelcatalan:materialsearchview:${Versions.materialSearchView}"
 }


### PR DESCRIPTION
### Description
- Added the library [MaterialSearchView](https://github.com/MiguelCatalan/MaterialSearchView)
that prevents boilerplate code and allows to easily use suggestions (could be used later by searching member by interests)
- SearchView with animation on expanding/closing according to material design
- Toolbar instead of ActionBar for SearchView to function properly
- filter functionality in MembersRVAdapter with marking the search query (see comments in the code)
- override onBackPressed() for the search function to close before transiting to home fragment
- added attribute android:windowSoftInputMode="adjustPan" in manifest.xml for BottomNavigationView to stay at the bottom and not go up as the search view expands

Fixes #266 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my phone

### Gif and Screenshots:
![20191209_124453](https://user-images.githubusercontent.com/34242059/70450471-122b2e80-1aa4-11ea-8147-e7efe72934a0.gif)
![Screenshot_20191209-124530_Systers Mentorship](https://user-images.githubusercontent.com/34242059/70450489-18b9a600-1aa4-11ea-939c-3987a518d6bf.jpg)
![Screenshot_20191209-124533_Systers Mentorship](https://user-images.githubusercontent.com/34242059/70450487-18210f80-1aa4-11ea-8016-b8dc1057ff33.jpg)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings