### PR TITLE
[Program:GCI]fix: retain values typed in EditText in EditProfile Dialog on orientation change

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -19,7 +19,7 @@ import org.systers.mentorship.models.User
 import org.systers.mentorship.utils.EditProfileFragmentErrorStates
 import org.systers.mentorship.view.activities.MainActivity
 import org.systers.mentorship.viewmodels.ProfileViewModel
-
+private const val RETRIEVE_USER = "user"
 /**
  * The fragment is responsible for editing the User's profile
  */
@@ -64,7 +64,8 @@ class EditProfileFragment: DialogFragment() {
         editProfileBinding = DataBindingUtil.inflate(LayoutInflater.from(context),
                 R.layout.fragment_edit_profile, null, false)
 
-        editProfileBinding.user = tempUser.copy()
+        editProfileBinding.user = savedInstanceState?.getParcelable(RETRIEVE_USER) ?: tempUser.copy()
+        //Restore state
         currentUser = tempUser.copy()
 
         val dialogBuilder = AlertDialog.Builder(context!!)
@@ -74,6 +75,11 @@ class EditProfileFragment: DialogFragment() {
         dialogBuilder.setNegativeButton(getString(R.string.cancel)) { _, _ -> }
 
         return dialogBuilder.create()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putParcelable(RETRIEVE_USER, editProfileBinding.user)//Save State
     }
 
     override fun onResume() {


### PR DESCRIPTION
fix: Retain values typed in EditText in EditProfile Dialog on orientation change

### Description
Fixes the problem of the EditText text being lost during orientation change.


### Type of Change:


- Code


### Code/Quality Assurance Only
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Tested on a physical device, Xiaomi Redmi 6A, running on Android 9.0 Pie. Here is a GIF of the EditText values that are retained when rotated in the app.
![gci-submission](https://user-images.githubusercontent.com/58442255/70547897-ab456c80-1bac-11ea-876b-e724884c7a24.gif)



### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules