### PR TITLE
[Program:GCI] feat: disable past dates in DatePickerDialog while sending mentorship requests

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
@@ -60,10 +60,12 @@ class SendRequestActivity: BaseActivity() {
             }
         }
         ivCalendar.setOnClickListener {
-          DatePickerDialog(this , date ,
-                  myCalendar.get(Calendar.YEAR) ,
-                  myCalendar.get(Calendar.MONTH) ,
-                  myCalendar.get(Calendar.DAY_OF_MONTH)).show()
+            val datePickerDialog = DatePickerDialog(this, date,
+                    myCalendar.get(Calendar.YEAR),
+                    myCalendar.get(Calendar.MONTH),
+                    myCalendar.get(Calendar.DAY_OF_MONTH))
+            datePickerDialog.datePicker.minDate = Calendar.getInstance().timeInMillis
+            datePickerDialog.show()
       }
     }
     private fun updateEndDateEditText() {


### PR DESCRIPTION
### Description
Past dates disabled in DatePickerDialog. For this datePicker.minDate property was added in SendRequestActivity.kt .
Reference: https://stackoverflow.com/a/57607621

Fixes #233

### Type of Change:
- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Screenshot
![task19_1](https://user-images.githubusercontent.com/50169911/70779282-3d669400-1daa-11ea-8ae3-5d115f304ab1.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works