### PR TITLE
[Program:GCI] feat: Use GSON's field naming policy to change field names between camel and snake case

### DIFF
--- a/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
+++ b/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.models
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -20,15 +19,10 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class HomeStatistics(
         val name: String,
-        @SerializedName("pending_requests")
         val pendingRequests: Int,
-        @SerializedName("accepted_requests")
         val acceptedRequests: Int,
-        @SerializedName("completed_relations")
         val completedRelations: Int,
-        @SerializedName("cancelled_relations")
         val cancelledRelations: Int,
-        @SerializedName("rejected_requests")
         val rejectedRequests: Int,
         val achievements: List<Task>): Parcelable
 

--- a/app/src/main/java/org/systers/mentorship/models/Relationship.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Relationship.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.models
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -15,10 +14,10 @@ import kotlinx.android.parcel.Parcelize
  * @param sentByMe indication if the current user was the action user
  * @param mentor user with mentor role in the relation
  * @param mentee user with mentee role in the relation
- * @param sentOn date of creation unix timestamp
- * @param acceptedOn date of acceptance unix timestamp
- * @param startsOn start date unix timestamp
- * @param endsOn end date unix timestamp
+ * @param creationDate date of creation unix timestamp
+ * @param acceptDate date of acceptance unix timestamp
+ * @param startDate start date unix timestamp
+ * @param endDate end date unix timestamp
  * @param state state of the relation (@link to RelationState)
  * @param notes notes related to the mentorship relation
  */
@@ -26,14 +25,14 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class Relationship(
         val id: Int,
-        @SerializedName("action_user_id") val actionUserId: Int,
-        @SerializedName("sent_by_me") val sentByMe: Boolean,
+        val actionUserId: Int,
+        val sentByMe: Boolean,
         val mentor: RelationUserResponse,
         val mentee: RelationUserResponse,
-        @SerializedName("creation_date")  val sentOn: Float,
-        @SerializedName("accept_date")  val acceptedOn: Float,
-        @SerializedName("start_date")  val startsOn: Float,
-        @SerializedName("end_date")  val endsOn: Float,
+        val creationDate: Float,
+        val acceptDate: Float,
+        val startDate: Float,
+        val endDate: Float,
         val state: Int,
         val notes: String): Parcelable {
     /**

--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.models
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -21,11 +20,7 @@ import kotlinx.android.parcel.Parcelize
 data class Task(
         val id: Int,
         val description: String,
-        @SerializedName("is_done")
         val isDone: Boolean,
-        @SerializedName("created_at")
         val createdAt: Float,
-        @SerializedName("completed_at")
         val completedAt: Float
 ): Parcelable
-

--- a/app/src/main/java/org/systers/mentorship/models/User.kt
+++ b/app/src/main/java/org/systers/mentorship/models/User.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.models
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
-import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -18,8 +17,8 @@ import kotlinx.android.parcel.Parcelize
  * @param organization organization to which the user might belong
  * @param interests interests the user possesses
  * @param skills skills the user possesses
- * @param needsMentoring true, if user wants to be mentored, false if otherwise
- * @param isAvailableToMentor true, if user is available to mentor, false if otherwise
+ * @param needMentoring true, if user wants to be mentored, false if otherwise
+ * @param availableToMentor true, if user is available to mentor, false if otherwise
  * @param slackUsername Slack username
  */
 @SuppressLint("ParcelCreator")
@@ -35,7 +34,7 @@ data class User(
         var organization: String? = null,
         var interests: String? = null,
         var skills: String? = null,
-        @SerializedName("need_mentoring") var needsMentoring: Boolean? = null,
-        @SerializedName("available_to_mentor") var isAvailableToMentor: Boolean? = null,
-        @SerializedName("slack_username") var slackUsername: String? = null
+        var needMentoring: Boolean? = null,
+        var availableToMentor: Boolean? = null,
+        var slackUsername: String? = null
 ) : Parcelable

--- a/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
@@ -1,5 +1,8 @@
 package org.systers.mentorship.remote
 
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.systers.mentorship.remote.services.AuthService
@@ -40,10 +43,13 @@ class ApiManager {
                 .addInterceptor(interceptor)
                 .addInterceptor(CustomInterceptor())
                 .build()
+        val gson = GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create()
 
         val retrofit = Retrofit.Builder()
                 .baseUrl(BaseUrl.apiBaseUrl)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create(gson))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .client(okHttpClient)
                 .build()

--- a/app/src/main/java/org/systers/mentorship/remote/requests/ChangePassword.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/ChangePassword.kt
@@ -1,13 +1,11 @@
 package org.systers.mentorship.remote.requests
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * This data class represents all data necessary to changing user password
  * @param currentPassword the current password of the user
  * @param newPassword new password which will replace the current password.
  */
 data class ChangePassword (
-        @SerializedName("current_password") val currentPassword: String,
-        @SerializedName("new_password") val newPassword: String
+        val currentPassword: String,
+        val newPassword: String
 )

--- a/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
@@ -1,21 +1,22 @@
 package org.systers.mentorship.remote.requests
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * This data class represents all data necessary to register a new user
  * @param name represents the name of the new user
  * @param username represents the username of the new user, used for login
  * @param email represents the email of the new user, used for login
  * @param password represents the password of the new user, used for login
- * @param hasAcceptedTermsAndConditions is true if the user checked the terms and
+ * @param termsAndConditionsChecked is true if the user checked the terms and
  *                                      conditions checkbox, false if otherwise
+ * @param needMentoring is true if user wants to be mentored
+ * @param availableToMentor is true if user is available as mentor
+
  */
 data class Register (
         val name: String,
         val username: String,
         val email: String,
         val password: String,
-        @SerializedName("terms_and_conditions_checked") val hasAcceptedTermsAndConditions: Boolean,
-        @SerializedName("need_mentoring") val needsMentoring: Boolean,
-        @SerializedName("available_to_mentor") val isAvailableToMentor: Boolean)
+        val termsAndConditionsChecked: Boolean,
+        val needMentoring: Boolean,
+        val availableToMentor: Boolean)

--- a/app/src/main/java/org/systers/mentorship/remote/requests/RelationshipRequest.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/RelationshipRequest.kt
@@ -1,7 +1,5 @@
 package org.systers.mentorship.remote.requests
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * This data class represents all data necessary to send a mentorship relation request
  * @param mentorId represents mentor user id
@@ -10,7 +8,7 @@ import com.google.gson.annotations.SerializedName
  * @param endDate represents end date of the mentorship relation
  */
 data class RelationshipRequest (
-        @SerializedName("mentor_id") val mentorId: Int,
-        @SerializedName("mentee_id") val menteeId: Int,
+        val mentorId: Int,
+        val menteeId: Int,
         val notes: String,
-        @SerializedName("end_date") val endDate: Long)
+        val endDate: Long)

--- a/app/src/main/java/org/systers/mentorship/remote/responses/AuthToken.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/responses/AuthToken.kt
@@ -1,11 +1,9 @@
 package org.systers.mentorship.remote.responses
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * This data class represents all data necessary to create an authentication token
- * @param authToken represents an authentication token
- * @param expiry represents the expiry timestamp
+ * @param accessToken represents an authentication token
+ * @param accessExpiry represents the expiry timestamp
  */
-data class AuthToken(@SerializedName("access_token") var authToken: String,
-                     @SerializedName("access_expiry") var accessExpiry: Float)
+data class AuthToken(var accessToken: String,
+                     var accessExpiry: Float)

--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -70,18 +70,18 @@ class MemberProfileActivity : BaseActivity() {
         userProfile = user
         tvName.text = user.name
 
-        if (user.isAvailableToMentor != null) {
+        if (user.availableToMentor != null) {
             setTextViewStartingWithBoldSpan(
                     tvAvailableToMentor,
                     getString(R.string.available_to_mentor),
-                    if (user.isAvailableToMentor!!)
+                    if (user.availableToMentor!!)
                         getString(R.string.yes) else getString(R.string.no))
         }
-        if (user.needsMentoring != null) {
+        if (user.needMentoring != null) {
             setTextViewStartingWithBoldSpan(
                     tvNeedMentoring,
                     getString(R.string.need_mentoring),
-                    if (user.needsMentoring!!)
+                    if (user.needMentoring!!)
                         getString(R.string.yes) else getString(R.string.no))
         }
         setTextViewStartingWithBoldSpan(tvBio, getString(R.string.bio), user.bio)

--- a/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
@@ -67,7 +67,7 @@ class RequestDetailActivity: BaseActivity() {
         }
         val actionUserRole = getString(if (isFromMentee) R.string.mentee else R.string.mentor)
         val requestEndDate = convertUnixTimestampIntoStr(
-                relationResponse.endsOn, EXTENDED_DATE_FORMAT)
+                relationResponse.endDate, EXTENDED_DATE_FORMAT)
 
         val requestSummaryMessage = getString(summaryStrId,
                 otherUserName, actionUserRole, requestEndDate)
@@ -84,7 +84,7 @@ class RequestDetailActivity: BaseActivity() {
     }
 
     private fun setActionButtons(relationResponse: Relationship) {
-        val hasEndTimePassed = getUnixTimestampInMilliseconds(relationResponse.endsOn) < System.currentTimeMillis()
+        val hasEndTimePassed = getUnixTimestampInMilliseconds(relationResponse.endDate) < System.currentTimeMillis()
         if (!hasEndTimePassed) {
             if (relationResponse.sentByMe) {
                 btnDelete.visibility = View.VISIBLE

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -54,8 +54,8 @@ class SignUpActivity : BaseActivity() {
             email = tiEmail.editText?.text.toString()
             password = tiPassword.editText?.text.toString()
             confirmedPassword = tiConfirmPassword.editText?.text.toString()
-            needsMentoring = cbMentee.isChecked
-            isAvailableToMentor = cbMentor.isChecked
+            needsMentoring = cbMentee.isChecked //old name but works
+            isAvailableToMentor = cbMentor.isChecked //old name but works
 
             if (validateDetails()) {
                 val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor)

--- a/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
@@ -34,7 +34,7 @@ class MembersAdapter (
         val itemView = holder.itemView
 
         itemView.tvName.text = item.name
-        itemView.tvMentorshipAvailability.text = getMentorshipAvailabilityText(item.isAvailableToMentor, item.needsMentoring)
+        itemView.tvMentorshipAvailability.text = getMentorshipAvailabilityText(item.availableToMentor, item.needMentoring)
 
         val userInterests = item.interests
         val validText = if (userInterests.isNullOrBlank()) NON_VALID_VALUE_REPLACEMENT else userInterests

--- a/app/src/main/java/org/systers/mentorship/view/adapters/RequestsAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/RequestsAdapter.kt
@@ -37,9 +37,9 @@ class RequestsAdapter (
 
         setTextViewStartingWithBoldSpan(itemView.tvMentorName, context.getString(R.string.mentor), item.mentor.name)
         setTextViewStartingWithBoldSpan(itemView.tvMenteeName, context.getString(R.string.mentee), item.mentee.name)
-        setTextViewStartingWithBoldSpan(itemView.tvEndDate, context.getString(R.string.end_date), convertUnixTimestampIntoStr(item.endsOn, DATE_FORMAT))
+        setTextViewStartingWithBoldSpan(itemView.tvEndDate, context.getString(R.string.end_date), convertUnixTimestampIntoStr(item.endDate, DATE_FORMAT))
         setTextViewStartingWithBoldSpan(itemView.tvNotes, context.getString(R.string.notes), item.notes)
-        itemView.tvCreationDate.text = convertUnixTimestampIntoStr(item.sentOn, DATE_FORMAT)
+        itemView.tvCreationDate.text = convertUnixTimestampIntoStr(item.creationDate, DATE_FORMAT)
 
         // switch arrow direction according to the user that sent a mentorship request
         if (!item.sentByMe) {

--- a/app/src/main/java/org/systers/mentorship/view/adapters/RequestsPagerAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/RequestsPagerAdapter.kt
@@ -37,14 +37,14 @@ class RequestsPagerAdapter(
     private val pendingList: List<Relationship> by lazy {
         requestsList.filter {
             val isPendingState = RelationState.PENDING.value == it.state
-            val hasEndTimePassed = getUnixTimestampInMilliseconds(it.endsOn) < System.currentTimeMillis()
+            val hasEndTimePassed = getUnixTimestampInMilliseconds(it.endDate) < System.currentTimeMillis()
 
             isPendingState && !hasEndTimePassed
         }
     }
     private val pastList: List<Relationship> by lazy {
         requestsList.filter {
-            val hasEndTimePassed = getUnixTimestampInMilliseconds(it.endsOn) < System.currentTimeMillis()
+            val hasEndTimePassed = getUnixTimestampInMilliseconds(it.endDate) < System.currentTimeMillis()
             val isAcceptedState = RelationState.ACCEPTED.value == it.state
 
             !isAcceptedState && hasEndTimePassed

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -77,7 +77,7 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
             tvMentorName.text = relationResponse.mentor.name
             tvMenteeName.text = relationResponse.mentee.name
             tvEndDate.text = convertUnixTimestampIntoStr(
-                    relationResponse.endsOn, EXTENDED_DATE_FORMAT)
+                    relationResponse.endDate, EXTENDED_DATE_FORMAT)
             tvRelationNotes.text = relationResponse.notes
             btnCancelRelation.visibility = View.VISIBLE
             btnCancelRelation.setOnClickListener {

--- a/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
@@ -44,7 +44,7 @@ class LoginViewModel : ViewModel() {
                 .subscribeWith(object : DisposableObserver<AuthToken>() {
                     override fun onNext(authToken: AuthToken) {
                         successful.value = true
-                        preferenceManager.putAuthToken(authToken.authToken)
+                        preferenceManager.putAuthToken(authToken.accessToken)
                     }
 
                     override fun onError(throwable: Throwable) {

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -111,7 +111,7 @@
                         android:id="@+id/switchNeedsMentoring"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:checked="@={user.needsMentoring}" />
+                        android:checked="@={user.needMentoring}" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -79,7 +79,7 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginTop="12dp"
                 android:enabled="false"
-                android:checked="@{safeUnbox(user.needsMentoring)}"
+                android:checked="@{safeUnbox(user.needMentoring)}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/switchAvailableToMentor" />
             <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
### Description
Use GSON's field naming policy to change field names between camel and snake case. Some variables had to be renamed for new GSON names. LOWER_CASE_WITH_UNDERSCORES GSON policy was used to replace occurrences of @SerializedName()

### Type of Change:
- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)

### How Has This Been Tested?
Images and GIFs
1. Sign up
![task22_1](https://user-images.githubusercontent.com/50169911/70868026-1bcffd00-1fa2-11ea-82c1-7c117abd9b46.gif)

2. Home screen
![image](https://user-images.githubusercontent.com/50169911/70868091-eaa3fc80-1fa2-11ea-8d61-96f85feb804d.png)

3. Profile
![image](https://user-images.githubusercontent.com/50169911/70868093-eed01a00-1fa2-11ea-8d98-d155b2928a36.png)

4. Edit profile
![task22_4](https://user-images.githubusercontent.com/50169911/70868017-f7742080-1fa1-11ea-9c8a-3a7d96989f4e.gif)

5. Send request to one of members
![task22_5](https://user-images.githubusercontent.com/50169911/70868038-44f08d80-1fa2-11ea-9528-1d8907dec030.gif)

6. Mentorship requests
![task22_6](https://user-images.githubusercontent.com/50169911/70868052-681b3d00-1fa2-11ea-8193-10dd61ea2be4.gif)

7. Accept request request
![task22_7](https://user-images.githubusercontent.com/50169911/70868064-8b45ec80-1fa2-11ea-975c-ae579351813b.gif)

8. Active mentorship relations
![image](https://user-images.githubusercontent.com/50169911/70868096-f2fc3780-1fa2-11ea-9dfb-2333958a0bf4.png)

9. Change password
![task22_9](https://user-images.githubusercontent.com/50169911/70868078-c2b49900-1fa2-11ea-9d53-e86c05f0db67.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings