### PR TITLE
[Program:GCI] feat: Make change password dialog non dismissable

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -61,7 +61,7 @@ class ChangePasswordFragment : DialogFragment() {
         super.onResume()
 
         val passwordDialog = dialog as? AlertDialog
-
+        passwordDialog?.setCanceledOnTouchOutside(false)
         passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {
             currentPassword = changePasswordView.tilCurrentPassword?.editText?.text.toString()
             newPassword = changePasswordView.tilNewPassword?.editText?.text.toString()


### PR DESCRIPTION
### Description
Make change password dialog in ChangePasswordFragment.kt non-dismissable. For this setCanceledOnTouchOutside() was set to false.

**Reference**: https://stackoverflow.com/questions/9829453/android-4-0-dialog-gets-canceled-when-touched-outside-of-dialog-window

### Type of Change:
- Code
- Quality Assurance- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. Before
![task23_1](https://user-images.githubusercontent.com/50169911/70885277-7434e800-1ffe-11ea-8b92-4bff0f3a5495.gif)

2. After
![task23_2](https://user-images.githubusercontent.com/50169911/70885608-561bb780-1fff-11ea-82b4-397e70731934.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works