### PR TITLE
[Program: GCI] Make change password dialog non dismissable [Mentorship - Android]

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -54,7 +54,10 @@ class ChangePasswordFragment : DialogFragment() {
         builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
             dialog.cancel()
         }
-        return builder.create()
+        builder.setCancelable(false)
+        val dialog = builder.create()
+        dialog.setCanceledOnTouchOutside(false)
+        return dialog
     }
 
     override fun onResume() {


### PR DESCRIPTION
### Description
Made change passoword dialog non dismissable

Fixes #366 

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This is was tested on an emulator and on my phone. Here's a GIF

This is on an emulator
![untitled](https://user-images.githubusercontent.com/29257061/70896252-67bc8980-2016-11ea-861d-4189f4668364.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules