### PR TITLE
[Program:GCI] style: remove "ParcelCreator" lint Suppressor from data classes

### DIFF
--- a/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
+++ b/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
@@ -16,7 +15,6 @@ import kotlinx.android.parcel.Parcelize
  * @param achievements a list of up-to 3 completed tasks
  */
 
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class HomeStatistics(
         val name: String,

--- a/app/src/main/java/org/systers/mentorship/models/Relationship.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Relationship.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
@@ -22,7 +21,6 @@ import kotlinx.android.parcel.Parcelize
  * @param state state of the relation (@link to RelationState)
  * @param notes notes related to the mentorship relation
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Relationship(
         val id: Int,

--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
@@ -16,7 +15,6 @@ import kotlinx.android.parcel.Parcelize
  * @param completedAt Unix timestamp of when this task was completed
  */
 
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Task(
         val id: Int,

--- a/app/src/main/java/org/systers/mentorship/models/User.kt
+++ b/app/src/main/java/org/systers/mentorship/models/User.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
@@ -22,7 +21,6 @@ import kotlinx.android.parcel.Parcelize
  * @param isAvailableToMentor true, if user is available to mentor, false if otherwise
  * @param slackUsername Slack username
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class User(
         var id: Int? = null,


### PR DESCRIPTION
### Description
Remove "ParcelCreator" lint Suppressor from data classes- User.kt, HomeStatistics.kt, Task.kt, Relationship.kt

### Type of Change:
- Code

### How Has This Been Tested?
1. Home screen (HomeStatistics.kt)
![image](https://user-images.githubusercontent.com/50169911/70897139-101f1d80-2018-11ea-83e0-d23c9c200464.png)

2. User profile and other member profiles (User.kt)
![image](https://user-images.githubusercontent.com/50169911/70897150-14e3d180-2018-11ea-8a99-69700a75f2aa.png)

![image](https://user-images.githubusercontent.com/50169911/70897170-1d3c0c80-2018-11ea-89f2-0a86d3a9f6c3.png)

3. Relationship (Relationship.kt)
![image](https://user-images.githubusercontent.com/50169911/70897306-5aa09a00-2018-11ea-8f73-6eef7e38a640.png)

4. Tasks (Task.kt)- button not implemented in gci-dev
![image](https://user-images.githubusercontent.com/50169911/70897201-2dec8280-2018-11ea-8f85-b001798a7409.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] I have added tests that prove my fix is effective or that my feature works