### PR TITLE
edit profile crash due to network issues

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -25,6 +25,7 @@ class ProfileFragment : BaseFragment() {
 
     private lateinit var fragmentProfileBinding: FragmentProfileBinding
     private lateinit var profileViewModel: ProfileViewModel
+    private var enableProfileEdit = false
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_profile
 
@@ -45,6 +46,7 @@ class ProfileFragment : BaseFragment() {
             if (successful != null) {
                 if (successful) {
                     fragmentProfileBinding.user = profileViewModel.user
+                    enableProfileEdit = true
                 } else {
                     Snackbar.make(fragmentProfileBinding.root, profileViewModel.message,
                             Snackbar.LENGTH_LONG).show()
@@ -63,8 +65,11 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
-                        getString(R.string.fragment_title_edit_profile))
+                // true if profileViewModel returns success
+                if (enableProfileEdit){
+                    EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
+                            getString(R.string.fragment_title_edit_profile))
+                }
                 true
             }
             else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
### Description
The app used to crash when Edit Profile button was pressed without having internet connection. Often the data from backend is slow to load, causing unexpected crashes. 

In the new code the edit profile screen is allowed to open only when enableProfileEdit (a new boolean variable)  becomes true. This happens when ProfileViewModel returns success. This pull request is not related to a GCI task, but is about an issue I raised earlier.

Fixes #331 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)

### How Has This Been Tested?
#### Issue earlier
![issue1_1](https://user-images.githubusercontent.com/50169911/70620314-f14a1100-1c3c-11ea-9a69-5908ab221ba0.gif)

#### Fix
1. When app is online
![issue1_2](https://user-images.githubusercontent.com/50169911/71059908-1fbe7380-218a-11ea-9a05-3906e7f86ef8.gif)

2. When app is offline
![issue1_3](https://user-images.githubusercontent.com/50169911/71059924-28af4500-218a-11ea-8f0e-a34468ce3dcb.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works