### PR TITLE
Remove deprecated AndroidJUnit4 in tests

### DIFF
--- a/app/src/androidTest/java/org/systers/mentorship/LoginActivityTest.kt
+++ b/app/src/androidTest/java/org/systers/mentorship/LoginActivityTest.kt
@@ -8,7 +8,6 @@ import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
 import android.view.View
 import android.widget.EditText
 import org.hamcrest.CoreMatchers.allOf
@@ -18,13 +17,11 @@ import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.systers.mentorship.view.activities.LoginActivity
 
 /**
  * This class specifies the UI test for LoginActivity
  */
-@RunWith(AndroidJUnit4::class)
 class LoginActivityTest {
     private val EMPTY_USERNAME_ERROR: String = "Username cannot be empty"
     private val EMPTY_PASSWORD_ERROR: String = "Password cannot be empty"

--- a/app/src/androidTest/java/org/systers/mentorship/SignUpActivityTest.kt
+++ b/app/src/androidTest/java/org/systers/mentorship/SignUpActivityTest.kt
@@ -11,7 +11,6 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
 import android.view.View
 import android.widget.EditText
 import org.hamcrest.Description
@@ -23,13 +22,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.systers.mentorship.view.activities.SignUpActivity
 
 /**
  * This class specifies the UI test for SignUpActivity
  */
-@RunWith(AndroidJUnit4::class)
 class SignUpActivityTest {
 
     private val EMPTY_USERNAME_ERROR: String = "Username cannot be empty"


### PR DESCRIPTION
### Description
Library AndroidJUnit4 has been deprecated but is still used for instrumentation tests. This pull request removes it's usage. The tests worked properly and no additional import statements were needed.

Fixes #380 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Before
![image](https://user-images.githubusercontent.com/50169911/71081454-3d550280-21b5-11ea-8bcc-74f60ba14add.png)

After
1. LoginActivityTest.kt
![ezgif-7-27e03dba2986](https://user-images.githubusercontent.com/50169911/71083070-3380ce80-21b8-11ea-8a4d-a1151ad19b86.gif)

![image](https://user-images.githubusercontent.com/50169911/71083485-22848d00-21b9-11ea-820c-ad0e9edb0497.png)

2. SignUpActivityTest.kt
![issue4_pull_2](https://user-images.githubusercontent.com/50169911/71082668-7db58000-21b7-11ea-807b-5b2c053e6ef2.gif)

![image](https://user-images.githubusercontent.com/50169911/71083501-2a443180-21b9-11ea-8fed-c725c1eeaafb.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes