### PR TITLE
[Program: GCI] models files unnecessarily suppressing "ParcelCreator" lint …

### DIFF
--- a/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
+++ b/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize

--- a/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
+++ b/app/src/main/java/org/systers/mentorship/models/HomeStatistics.kt
@@ -16,7 +16,6 @@ import kotlinx.android.parcel.Parcelize
  * @param achievements a list of up-to 3 completed tasks
  */
 
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class HomeStatistics(
         val name: String,

--- a/app/src/main/java/org/systers/mentorship/models/Relationship.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Relationship.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize

--- a/app/src/main/java/org/systers/mentorship/models/Relationship.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Relationship.kt
@@ -22,7 +22,6 @@ import kotlinx.android.parcel.Parcelize
  * @param state state of the relation (@link to RelationState)
  * @param notes notes related to the mentorship relation
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Relationship(
         val id: Int,

--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize

--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -16,7 +16,6 @@ import kotlinx.android.parcel.Parcelize
  * @param completedAt Unix timestamp of when this task was completed
  */
 
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class Task(
         val id: Int,

--- a/app/src/main/java/org/systers/mentorship/models/User.kt
+++ b/app/src/main/java/org/systers/mentorship/models/User.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.models
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize

--- a/app/src/main/java/org/systers/mentorship/models/User.kt
+++ b/app/src/main/java/org/systers/mentorship/models/User.kt
@@ -22,7 +22,6 @@ import kotlinx.android.parcel.Parcelize
  * @param isAvailableToMentor true, if user is available to mentor, false if otherwise
  * @param slackUsername Slack username
  */
-@SuppressLint("ParcelCreator")
 @Parcelize
 data class User(
         var id: Int? = null,


### PR DESCRIPTION
### Description
Fixing the model files in org.systers.mentorship.model that are
unnecessarily suppressing "ParcelCreator" lint Suppressor from data classes by removing the line @SuppressLint("ParcelCreator") from these files.

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran this on an android emulator on Android Studio to ensure that the app still works. Below are some screenshots of different activities related to the org.systers.mentorship.model files.

<img width="276" alt="Screen Shot 2019-12-19 at 12 34 45 AM" src="https://user-images.githubusercontent.com/23027638/71105379-6fd41f00-21f8-11ea-9145-ba77705e57f0.png">
 working normally.
<img width="275" alt="Screen Shot 2019-12-19 at 12 28 56 AM" src="https://user-images.githubusercontent.com/23027638/71105206-166bf000-21f8-11ea-88bb-6c682b17de32.png">
<img width="276" alt="Screen Shot 2019-12-19 at 12 30 07 AM" src="https://user-images.githubusercontent.com/23027638/71105248-2e437400-21f8-11ea-9183-9fcf55551236.png">
<img width="276" alt="Screen Shot 2019-12-19 at 12 30 34 AM" src="https://user-images.githubusercontent.com/23027638/71105321-5206ba00-21f8-11ea-9c3d-833ba56bd7ec.png">


### Checklist
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings