### PR TITLE
[Program GCI] REMOVE "PARCELCREATOR" LINT SUPPRESSOR FROM DATA CLASSES

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            manifestPlaceholders = [usesCleartextTraffic:"false"]
+        }
+        debug {
+            manifestPlaceholders = [usesCleartextTraffic:"true"]
         }
     }
     dataBinding {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:theme="@style/AppTheme">
         <activity android:name=".view.activities.AboutActivity"></activity>
         <activity


### PR DESCRIPTION
### Description
Some files in the package org.systers.mentorship.models are unnecessarily suppressing "ParcelCreator" lint warning.
Find the files and remove the line @SuppressLint("ParcelCreator") from these files

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code



### How Has This Been Tested?
Tested manually.No changes seen in the application.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


![Screenshot_2019-12-18-17-42-11-904_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160403-7d77bc00-226d-11ea-9b19-c215d81b4e33.png)
![Screenshot_2019-12-18-17-42-17-186_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160444-91bbb900-226d-11ea-9181-e1ebe5683d10.png)
![Screenshot_2019-12-18-17-42-21-231_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160529-c16ac100-226d-11ea-9bdf-ad1afd292d35.png)
![Screenshot_2019-12-18-17-42-25-334_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160559-cfb8dd00-226d-11ea-9052-d5e986a97199.png)
![Screenshot_2019-12-18-17-42-29-309_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160588-de06f900-226d-11ea-86e5-838b976b169d.png)
![Screenshot_2019-12-18-17-42-36-707_org systers mentorship](https://user-images.githubusercontent.com/58589974/71160620-ebbc7e80-226d-11ea-975d-d383c2d5c1da.png)

