### PR TITLE
[Program:GCI] Center-align the Text on About Page

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -30,6 +30,7 @@
                 android:layout_gravity="center"
                 android:layout_margin="@dimen/generic_28sp"
                 android:text="@string/about_systers"
+                android:textAlignment="center"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 
@@ -38,6 +39,7 @@
                 android:layout_height="76dp"
                 android:layout_gravity="center"
                 android:text="@string/about_app"
+                android:textAlignment="center"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 


### PR DESCRIPTION
### Description
This center aligns the TextViews displayed on the About screen(activity_about.xml)

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
I ran the app on Android Studio and made sure the text is center aligned.
<img width="278" alt="Screen Shot 2019-12-21 at 12 35 09 PM" src="https://user-images.githubusercontent.com/33010985/71313578-8c867780-23ef-11ea-98ad-bc69ac337634.png">



### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings