### PR TITLE
Add encryption for password field

### DIFF
--- a/app/src/main/java/org/systers/mentorship/utils/Constants.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Constants.kt
@@ -9,4 +9,7 @@ object Constants {
     const val RELATIONSHIP_EXTRA = "relationship_extra"
     const val DELETE_REQUEST_RESULT_ID = 1000
     const val REQUEST_ID = "request_id"
+    const val PASSWORD_MIN_LENGTH = 7
+    const val PASSWORD_MAX_LENGTH = 26
+
 }

--- a/app/src/main/java/org/systers/mentorship/utils/Extensions.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Extensions.kt
@@ -1,0 +1,11 @@
+package org.systers.mentorship.utils
+
+import java.math.BigInteger
+import java.security.MessageDigest
+
+// encrypts the given String via SHA 256 and returns a hex representation of it
+fun String.encrypt(): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.update(this.toByteArray())
+    return String.format("%064x", BigInteger(1, digest.digest()))
+}

--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -10,6 +10,7 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_login.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.Login
+import org.systers.mentorship.utils.encrypt
 import org.systers.mentorship.viewmodels.LoginViewModel
 
 /**
@@ -83,7 +84,7 @@ class LoginActivity : BaseActivity() {
         username = tiUsername.editText?.text.toString()
         password = tiPassword.editText?.text.toString()
         if (validateCredentials()) {
-            loginViewModel.login(Login(username, password))
+            loginViewModel.login(Login(username, password.encrypt()))
             showProgressDialog(getString(R.string.logging_in))
         }
     }

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -10,6 +10,9 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_sign_up.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.Register
+import org.systers.mentorship.utils.Constants.PASSWORD_MAX_LENGTH
+import org.systers.mentorship.utils.Constants.PASSWORD_MIN_LENGTH
+import org.systers.mentorship.utils.encrypt
 import org.systers.mentorship.viewmodels.SignUpViewModel
 
 /**
@@ -58,7 +61,8 @@ class SignUpActivity : BaseActivity() {
             isAvailableToMentor = cbMentor.isChecked
 
             if (validateDetails()) {
-                val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor)
+                val requestData = Register(name, username, email, password.encrypt()
+                        , true, needsMentoring, isAvailableToMentor)
                 signUpViewModel.register(requestData)
                 showProgressDialog(getString(R.string.signing_up))
             }
@@ -100,8 +104,9 @@ class SignUpActivity : BaseActivity() {
             tiEmail.error = null
         }
 
-        if (password.isBlank()) {
-            tiPassword.error = getString(R.string.error_empty_password)
+        if (password.length <= PASSWORD_MIN_LENGTH || password.length >= PASSWORD_MAX_LENGTH) {
+            tiPassword.error = getString(R.string.error_wrong_password_length,
+                    PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)
             isValid = false
         } else {
             tiPassword.error = null

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -9,9 +9,14 @@ import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_sign_up.*
 import kotlinx.android.synthetic.main.fragment_change_password.view.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.ChangePassword
+import org.systers.mentorship.utils.Constants
+import org.systers.mentorship.utils.Constants.PASSWORD_MAX_LENGTH
+import org.systers.mentorship.utils.Constants.PASSWORD_MIN_LENGTH
+import org.systers.mentorship.utils.encrypt
 import org.systers.mentorship.viewmodels.ChangePasswordViewModel
 
 /**
@@ -71,12 +76,18 @@ class ChangePasswordFragment : DialogFragment() {
             changePasswordView.tilNewPassword?.error = null
 
             if (validatePassword()) {
-                changePasswordViewModel.changeUserPassword(ChangePassword(currentPassword, newPassword))
+                changePasswordViewModel.changeUserPassword(ChangePassword(currentPassword.encrypt(), newPassword.encrypt()))
             }
         }
     }
 
-    private fun validatePassword() : Boolean {
+    private fun validatePassword(): Boolean {
+        if (newPassword.length <= PASSWORD_MIN_LENGTH || newPassword.length >= PASSWORD_MAX_LENGTH) {
+            changePasswordView.tilNewPassword?.error = getString(R.string.error_wrong_password_length,
+                    PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)
+            return false
+        } else
+            changePasswordView.tilNewPassword?.error = null
         return if (newPassword == confirmPassword && newPassword != currentPassword) {
             true
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="confirm_password">Confirm Password</string>
     <string name="terms_and_conditions_acceptance_statement">By checking this box, I affirm that I have read and accept to be bound by the AnitaB.org <a href="https://ghc.anitab.org/code-of-conduct/">Code of Conduct</a>, <a href="https://anitab.org/terms-of-use/">Terms</a>, and <a href="https://anitab.org/privacy-policy/">Privacy Policy</a>. Further, I consent to the use of my information for the stated purpose.</string>
     <string name="error_not_matching_passwords">Passwords didn\'t match!</string>
+    <string name="error_wrong_password_length">Password has to be longer than %d characters and shorter than %d characters!</string>
     <string name="error_please_check_internet">Please check your internet connection</string>
     <string name="error_request_timed_out">Request timed out</string>
     <string name="error_something_went_wrong">Something went wrong</string>


### PR DESCRIPTION
## Description
- added extension function to encrypt the String via SHA 256
- added password check length as it should not be checked at the backend anymore (SHA 256 String needs 64 characters)

Fixes #405 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my phone.

For password: `qwertzui` the function returns `4a7e0eba622867c0f1253399557136754a1482dc27a7c93bb8ec57acb4df7cb9`

### Screenshot:
![Screenshot_20191224-004443_Systers Mentorship](https://user-images.githubusercontent.com/34242059/71385955-c40d4380-25ea-11ea-848e-cfd0735ee945.jpg)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings