### PR TITLE
[Program: GCI] App crash on orientation change while creating new task

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/adapters/RelationPagerAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/RelationPagerAdapter.kt
@@ -32,11 +32,15 @@ class RelationPagerAdapter(fm: FragmentManager, private var mentorshipRelation: 
     override fun getItem(position: Int): Fragment {
         when (position) {
             TabsIndex.DETAILS.value -> {
-                return RelationFragment.newInstance(mentorshipRelation)
+                val relationFragment = RelationFragment.newInstance(mentorshipRelation)
+                relationFragment.retainInstance = true
+                return relationFragment
             }
 
             TabsIndex.TASKS.value -> {
-                return TasksFragment.newInstance(mentorshipRelation)
+                val tasksFragment = TasksFragment.newInstance(mentorshipRelation)
+                tasksFragment.retainInstance = true
+                return tasksFragment
             }
         }
         return TasksFragment.newInstance(mentorshipRelation)


### PR DESCRIPTION
### Description
Fixed app crash on orientation change while creating new task. This was done by setting ```retainInstance``` for relationFragment and tasksFragment as true.

Fixes #221 

#### Error messages
1. Unable to instantiate **RelationFragment**
```sh
EXCEPTION: main
    java.lang.RuntimeException: Unable to start activity ComponentInfo{org.systers.mentorship/org.systers.mentorship.view.activities.MainActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.systers.mentorship.view.fragments.RelationFragment: could not find Fragment constructor
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2646)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2707)
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4483)
        at android.app.ActivityThread.-wrap19(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1466)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6077)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
        at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:107)
     Caused by: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.systers.mentorship.view.fragments.RelationFragment: could not find Fragment constructor
```

2. Unable to instantiate **TasksFragment**
```sh
    java.lang.RuntimeException: Unable to start activity ComponentInfo{org.systers.mentorship/org.systers.mentorship.view.activities.MainActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.systers.mentorship.view.fragments.TasksFragment: could not find Fragment constructor
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2646)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2707)
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4483)
        at android.app.ActivityThread.-wrap19(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1466)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6077)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
        at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:107)
     Caused by: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment org.systers.mentorship.view.fragments.TasksFragment: could not find Fragment constructor
```

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. **crash**
![task34_1](https://user-images.githubusercontent.com/50169911/71410660-29eddf80-266c-11ea-97af-7952868229d1.gif)

2. **fix**
![task34_2](https://user-images.githubusercontent.com/50169911/71410665-2d816680-266c-11ea-9374-5b57e1147856.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules