### PR TITLE
[Program: GCI] Fix the app crash when orientation is changed while creating a new task 

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -42,7 +42,7 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-
+        retainInstance=true
         activityCast.showProgressDialog(getString(R.string.fetching_users))
         populateView(mentorshipRelation)
         relationViewModel = ViewModelProviders.of(this).get(RelationViewModel::class.java)

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -41,7 +41,7 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-
+        retainInstance=true
         taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
         taskViewModel.successful.observe(this, Observer {
             successful ->


### PR DESCRIPTION
### Description
There was an error about Retaining Instance when the screen orientation changed when creating a new task. 


### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested manually.
![3](https://user-images.githubusercontent.com/58389054/71441060-2c017e00-2700-11ea-96c9-bc4d43704140.gif)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
