### PR TITLE
Handle app with token has expired

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,13 @@ android {
     androidExtensions {
         experimental = true
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 configurations.all {
@@ -65,4 +72,6 @@ dependencies {
 
     implementation Dependencies.lifecycle_extensions
     implementation Dependencies.lifecycle_viewmodel
+
+    implementation Dependencies.work_manager
 }

--- a/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
@@ -2,10 +2,7 @@ package org.systers.mentorship.remote
 
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import org.systers.mentorship.remote.services.AuthService
-import org.systers.mentorship.remote.services.RelationService
-import org.systers.mentorship.remote.services.TaskService
-import org.systers.mentorship.remote.services.UserService
+import org.systers.mentorship.remote.services.*
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
@@ -19,6 +16,7 @@ class ApiManager {
     val relationService: RelationService
     val userService: UserService
     val taskService: TaskService
+    val refreshService: RefreshService
 
     companion object {
         private var apiManager: ApiManager? = null
@@ -52,5 +50,19 @@ class ApiManager {
         relationService = retrofit.create(RelationService::class.java)
         userService = retrofit.create(UserService::class.java)
         taskService = retrofit.create(TaskService::class.java)
+
+        val okHttpClientRefresh = OkHttpClient.Builder()
+                .addInterceptor(interceptor)
+                .addInterceptor(CustomRefreshInterceptor())
+                .build()
+
+        val retrofitRefresh = Retrofit.Builder()
+                .baseUrl(BaseUrl.apiBaseUrl)
+                .addConverterFactory(GsonConverterFactory.create())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .client(okHttpClientRefresh)
+                .build()
+
+        refreshService = retrofitRefresh.create(RefreshService::class.java)
     }
 }

--- a/app/src/main/java/org/systers/mentorship/remote/CustomRefreshInterceptor.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/CustomRefreshInterceptor.kt
@@ -1,0 +1,25 @@
+package org.systers.mentorship.remote
+
+import android.text.TextUtils
+import androidx.annotation.NonNull
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.systers.mentorship.utils.PreferenceManager
+
+class CustomRefreshInterceptor : Interceptor {
+
+    var preferenceManager: PreferenceManager = PreferenceManager()
+
+    override fun intercept(@NonNull chain: Interceptor.Chain): Response {
+        val chainRequest = chain.request()
+        val builder = chainRequest.newBuilder()
+
+        val accessToken = preferenceManager.refreshToken
+
+        if (!TextUtils.isEmpty(accessToken))
+            builder.header("Authorization", accessToken)
+
+        val request = builder.build()
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/AuthDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/AuthDataManager.kt
@@ -4,6 +4,7 @@ import io.reactivex.Observable
 import org.systers.mentorship.remote.ApiManager
 import org.systers.mentorship.remote.requests.Login
 import org.systers.mentorship.remote.requests.Register
+import org.systers.mentorship.remote.responses.AuthRefreshToken
 import org.systers.mentorship.remote.responses.AuthToken
 import org.systers.mentorship.remote.responses.CustomResponse
 
@@ -17,9 +18,9 @@ class AuthDataManager {
     /**
      * This will call the login method of AuthService interface
      * @param login The login request body containing the credentials
-     * @return an Observable AuthToken
+     * @return an Observable AuthRefreshToken
      */
-    fun login(login: Login): Observable<AuthToken> {
+    fun login(login: Login): Observable<AuthRefreshToken> {
         return apiManager.authService.login(login)
     }
 
@@ -32,4 +33,13 @@ class AuthDataManager {
     fun register(register: Register): Observable<CustomResponse> {
         return apiManager.authService.register(register)
     }
+
+    /**
+     * This will call the refresh method of AuthService interface
+     * @return an Observable AuthToken
+     */
+    fun refreshToken(): Observable<AuthToken> {
+        return apiManager.refreshService.refreshToken()
+    }
+
 }

--- a/app/src/main/java/org/systers/mentorship/remote/responses/AuthRefreshToken.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/responses/AuthRefreshToken.kt
@@ -1,0 +1,15 @@
+package org.systers.mentorship.remote.responses
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * This data class represents all data necessary to create an authentication token
+ * @param authToken represents an authentication token
+ * @param accessExpiry represents the authentication expiry timestamp
+ * @param refreshToken represents an refresh token
+ * @param refreshExpiry represents the refresh expiry timestamp
+ */
+data class AuthRefreshToken(@SerializedName("access_token") var authToken: String,
+                            @SerializedName("access_expiry") var accessExpiry: Float,
+                            @SerializedName("refresh_token") var refreshToken: String,
+                            @SerializedName("refresh_expiry") var refreshExpiry: Float)

--- a/app/src/main/java/org/systers/mentorship/remote/responses/AuthToken.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/responses/AuthToken.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 /**
  * This data class represents all data necessary to create an authentication token
  * @param authToken represents an authentication token
- * @param expiry represents the expiry timestamp
+ * @param accessExpiry represents the authentication expiry timestamp
  */
 data class AuthToken(@SerializedName("access_token") var authToken: String,
                      @SerializedName("access_expiry") var accessExpiry: Float)

--- a/app/src/main/java/org/systers/mentorship/remote/services/AuthService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/AuthService.kt
@@ -3,7 +3,7 @@ package org.systers.mentorship.remote.services
 import io.reactivex.Observable
 import org.systers.mentorship.remote.requests.Login
 import org.systers.mentorship.remote.requests.Register
-import org.systers.mentorship.remote.responses.AuthToken
+import org.systers.mentorship.remote.responses.AuthRefreshToken
 import org.systers.mentorship.remote.responses.CustomResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -16,10 +16,10 @@ interface AuthService {
     /**
      * This function allows a user to login into the system
      * @param login data required to login a user
-     * @return an observable instance of the [AuthToken]
+     * @return an observable instance of the [AuthRefreshToken]
      */
     @POST("login")
-    fun login(@Body login: Login): Observable<AuthToken>
+    fun login(@Body login: Login): Observable<AuthRefreshToken>
 
     /**
      * This function allows a user to sign up into the system

--- a/app/src/main/java/org/systers/mentorship/remote/services/RefreshService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/RefreshService.kt
@@ -1,0 +1,17 @@
+package org.systers.mentorship.remote.services
+
+import io.reactivex.Observable
+import org.systers.mentorship.remote.responses.AuthToken
+import retrofit2.http.POST
+
+interface RefreshService {
+
+    /**
+     * This function allows a user to get a new auth token
+     * @param refreshToken refresh token
+     * @return an observable instance of the [AuthToken]
+     */
+    @POST("refresh")
+    fun refreshToken(): Observable<AuthToken>
+
+}

--- a/app/src/main/java/org/systers/mentorship/utils/PreferenceManager.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/PreferenceManager.kt
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.remote.responses.AuthRefreshToken
+import org.systers.mentorship.remote.responses.AuthToken
 
 /**
  * This class contains SharedPreferences utilities, such as methods to save and clear application sensitive data.
@@ -13,6 +15,9 @@ class PreferenceManager {
     companion object {
         const val APPLICATION_PREFERENCE = "app-preferences"
         const val AUTH_TOKEN = "auth-token"
+        const val AUTH_EXPIRY = "auth-expiry"
+        const val REFRESH_TOKEN = "refresh-token"
+        const val REFRESH_EXPIRY = "refresh-expiry"
     }
 
     private val context: Context = MentorshipApplication.getContext()
@@ -21,16 +26,44 @@ class PreferenceManager {
 
     /**
      * Saves the authorization token to SharedPreferences file.
-     * @param authToken String which is the authorization token
+     * @param authRefreshToken AuthRefreshToken which is the authorization and refresh token
      */
     @SuppressLint("ApplySharedPref")
     //Cannot use .apply(), it will take time to save the token. We need token ASAP
-    fun putAuthToken(authToken: String) {
-        sharedPreferences.edit().putString(AUTH_TOKEN, "Bearer $authToken").commit()
+    fun putAuthRefreshToken(authRefreshToken: AuthRefreshToken) {
+        sharedPreferences.edit().putString(AUTH_TOKEN, "Bearer ${authRefreshToken.authToken}").commit()
+        sharedPreferences.edit().apply {
+            putFloat(AUTH_EXPIRY, authRefreshToken.accessExpiry)
+            putString(REFRESH_TOKEN, "Bearer ${authRefreshToken.refreshToken}")
+            putFloat(REFRESH_EXPIRY, authRefreshToken.refreshExpiry)
+            apply()
+        }
+    }
+
+    /**
+     * Saves the authorization token to SharedPreferences file.
+     * @param authToken AuthToken which is the authorization token
+     */
+    @SuppressLint("ApplySharedPref")
+    fun putAuthToken(authToken: AuthToken) {
+        sharedPreferences.edit().apply {
+            putString(AUTH_TOKEN, "Bearer ${authToken.authToken}")
+            putFloat(AUTH_EXPIRY, authToken.accessExpiry)
+            apply()
+        }
     }
 
     val authToken: String
-        get() = sharedPreferences.getString(AUTH_TOKEN, "")
+        get() = sharedPreferences.getString(AUTH_TOKEN, "") ?: ""
+
+    val authExpiry: Float
+        get() = sharedPreferences.getFloat(AUTH_EXPIRY, 0f)
+
+    val refreshToken: String
+        get() = sharedPreferences.getString(REFRESH_TOKEN, "") ?: ""
+
+    val refreshExpiry: Float
+        get() = sharedPreferences.getFloat(REFRESH_EXPIRY, 0f)
 
     /**
      * Clears all the data that has been saved in the preferences file.

--- a/app/src/main/java/org/systers/mentorship/utils/TokenWorker.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/TokenWorker.kt
@@ -1,0 +1,76 @@
+package org.systers.mentorship.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.observers.DisposableObserver
+import io.reactivex.schedulers.Schedulers
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.remote.datamanager.AuthDataManager
+import org.systers.mentorship.remote.responses.AuthToken
+import retrofit2.HttpException
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+/*
+    * This class refreshes the access token automatically if it is expired
+    *  and then puts it in the database.
+    *  This will be called every hour.
+ */
+class TokenWorker(context: Context, workerParams: WorkerParameters)
+    : Worker(context, workerParams) {
+
+    private val TAG = TokenWorker::class.java.simpleName
+    private val preferenceManager = PreferenceManager()
+    private val authDataManager: AuthDataManager = AuthDataManager()
+    private var message = ""
+    private var successful = true
+
+    @SuppressLint("CheckResult")
+    override fun doWork(): Result {
+        if (getUnixTimestampInMilliseconds(preferenceManager.authExpiry) < System.currentTimeMillis()
+                && getUnixTimestampInMilliseconds(preferenceManager.refreshExpiry) > System.currentTimeMillis()) {
+            authDataManager.refreshToken()
+                    .subscribeOn(Schedulers.newThread())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribeWith(object : DisposableObserver<AuthToken>() {
+                        override fun onNext(authToken: AuthToken) {
+                            preferenceManager.putAuthToken(authToken)
+                            successful = true
+                        }
+
+                        override fun onError(throwable: Throwable) {
+                            when (throwable) {
+                                is IOException ->
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_please_check_internet)
+                                is TimeoutException ->
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_request_timed_out)
+                                is HttpException ->
+                                    message = CommonUtils.getErrorResponse(throwable).message
+                                else -> {
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_something_went_wrong)
+                                    Log.e(TAG, throwable.localizedMessage)
+                                }
+                            }
+                            successful = false
+                        }
+
+                        override fun onComplete() {}
+                    })
+        } else return Result.failure()
+
+        if (message.isNotEmpty())
+            Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
+
+        return if (successful) Result.success() else Result.retry()
+    }
+
+}

--- a/app/src/main/java/org/systers/mentorship/view/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SplashScreenActivity.kt
@@ -3,9 +3,11 @@ package org.systers.mentorship.view.activities
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.PreferenceManager
+import org.systers.mentorship.utils.getUnixTimestampInMilliseconds
 
 /**
  * This activity will show the organisation logo for sometime and then start the next activity
@@ -21,11 +23,16 @@ class SplashScreenActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash_screen)
 
-        val intent = if (preferenceManager.authToken.isEmpty()) {
-            Intent(this, LoginActivity::class.java)
-        } else {
-            Intent(this, MainActivity::class.java)
-        }
+        var intent =
+                Intent(this,
+                        if (preferenceManager.authToken.isEmpty()) LoginActivity::class.java
+                        else MainActivity::class.java)
+
+        if (getUnixTimestampInMilliseconds(preferenceManager.authExpiry) < System.currentTimeMillis())
+            if (getUnixTimestampInMilliseconds(preferenceManager.refreshExpiry) < System.currentTimeMillis()) {
+                intent = Intent(this, LoginActivity::class.java)
+                Toast.makeText(applicationContext, R.string.token_expired, Toast.LENGTH_LONG).show()
+            }
 
         runnable = Runnable {
             startActivity(intent)

--- a/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
@@ -12,7 +12,7 @@ import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.AuthDataManager
 import org.systers.mentorship.remote.requests.Login
-import org.systers.mentorship.remote.responses.AuthToken
+import org.systers.mentorship.remote.responses.AuthRefreshToken
 import org.systers.mentorship.utils.CommonUtils
 import org.systers.mentorship.utils.PreferenceManager
 import retrofit2.HttpException
@@ -41,10 +41,10 @@ class LoginViewModel : ViewModel() {
         authDataManager.login(login)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<AuthToken>() {
-                    override fun onNext(authToken: AuthToken) {
+                .subscribeWith(object : DisposableObserver<AuthRefreshToken>() {
+                    override fun onNext(authRefreshToken: AuthRefreshToken) {
                         successful.value = true
-                        preferenceManager.putAuthToken(authToken.authToken)
+                        preferenceManager.putAuthRefreshToken(authRefreshToken)
                     }
 
                     override fun onError(throwable: Throwable) {
@@ -58,7 +58,7 @@ class LoginViewModel : ViewModel() {
                                         .getString(R.string.error_request_timed_out)
                             }
                             is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
+                                message = CommonUtils.getErrorResponse(throwable).message
                             }
                             else -> {
                                 message = MentorshipApplication.getContext()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,5 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="token_expired">The token has expired! Please, login again.</string>
 </resources>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val testRule = "1.1.0"
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
-
+    const val workManager = "2.2.0"
 }
 
 /**
@@ -53,4 +53,5 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+    const val work_manager = "androidx.work:work-runtime-ktx:${Versions.workManager}"
 }


### PR DESCRIPTION
### Description
- Added refresh token functionality
- Updated AuthToken (it didn't have `refresh_token` and `refresh_expiry` fields in it)
- Added `TokenWorker` and `WorkManager` library from JetPack

Fixes #113 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my phone. I changed the `auth_expiry` field so that the authentication token would be expired and then printed a new `auth_token` given by `TokenWorker`.

### Screenshot:
![Screenshot (46)](https://user-images.githubusercontent.com/34242059/71481945-5d617300-2800-11ea-93fa-94ec23b90d27.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings