### PR TITLE
Retain EditTexts' values on screen orientation change in SignUpActivity

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -49,11 +49,11 @@ class SignUpActivity : BaseActivity() {
 
         btnSignUp.setOnClickListener {
 
-            name = tiName.editText?.text.toString()
-            username = tiUsername.editText?.text.toString()
-            email = tiEmail.editText?.text.toString()
-            password = tiPassword.editText?.text.toString()
-            confirmedPassword = tiConfirmPassword.editText?.text.toString()
+            name = etName.text.toString()
+            username = etUsername.text.toString()
+            email = etEmail.text.toString()
+            password = etPassword.text.toString()
+            confirmedPassword = etConfirmPassword.text.toString()
             needsMentoring = cbMentee.isChecked
             isAvailableToMentor = cbMentor.isChecked
 

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -37,6 +37,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tvSignUp">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textPersonName" />
@@ -53,6 +54,7 @@
             app:layout_constraintTop_toBottomOf="@id/tiName">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etUsername"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
@@ -69,6 +71,7 @@
             app:layout_constraintTop_toBottomOf="@id/tiUsername">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etEmail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
@@ -86,6 +89,7 @@
             app:passwordToggleEnabled="true">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etPassword"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textPassword" />
@@ -103,6 +107,7 @@
             app:passwordToggleEnabled="true">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etConfirmPassword"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:inputType="textPassword" />


### PR DESCRIPTION
### Description
- Added id for each EditText in order to Retain its value on screen orientation change in SignUpActivity
- That also allows us to directly use it in `SignUpActivty.kt` instead of calling, for instance, `tiName.editText?.text`

Fixes #246 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The code was tested on my phone.

### Gifs:

before:
![20191226_224604](https://user-images.githubusercontent.com/34242059/71491581-c2818c80-2831-11ea-9746-702d8f71c703.gif)

after:
![20191226_223915](https://user-images.githubusercontent.com/34242059/71491586-c44b5000-2831-11ea-8261-ab2e69f36f35.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes