### PR TITLE
Add NetworkStateReceiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.systers.mentorship">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -13,6 +14,13 @@
         android:supportsRtl="true"
         android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:theme="@style/AppTheme">
+        <receiver android:name=".utils.NetworkStateReceiver"
+            android:label="NetworkStateReceiver">
+            <intent-filter>
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+                <action android:name="android.net.wifi.WIFI_STATE_CHANGED" />
+            </intent-filter>
+        </receiver>
         <activity android:name=".view.activities.AboutActivity"></activity>
         <activity
             android:name=".view.activities.SplashScreenActivity"

--- a/app/src/main/java/org/systers/mentorship/MentorshipApplication.kt
+++ b/app/src/main/java/org/systers/mentorship/MentorshipApplication.kt
@@ -2,7 +2,9 @@ package org.systers.mentorship
 
 import android.app.Application
 import android.content.Context
+import android.content.IntentFilter
 import androidx.appcompat.app.AppCompatDelegate
+import org.systers.mentorship.utils.NetworkStateReceiver
 
 /**
  * The entry point, a class that represents Mentorship application.
@@ -31,6 +33,9 @@ class MentorshipApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        val intentFilter = IntentFilter("android.net.conn.CONNECTIVITY_CHANGE")
+        registerReceiver(NetworkStateReceiver(), intentFilter)
 
         instance = this
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)

--- a/app/src/main/java/org/systers/mentorship/utils/NetworkStateReceiver.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/NetworkStateReceiver.kt
@@ -1,0 +1,21 @@
+package org.systers.mentorship.utils
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import androidx.lifecycle.MutableLiveData
+
+class NetworkStateReceiver : BroadcastReceiver() {
+
+    companion object {
+        val isOnline = MutableLiveData<Boolean>()
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        val cm = context?.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val netInfo = cm.activeNetworkInfo
+        isOnline.value = netInfo != null && netInfo.isConnected
+    }
+
+}

--- a/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
@@ -14,6 +14,7 @@ import org.systers.mentorship.R
 import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import org.systers.mentorship.utils.SingleLiveEvent
 import retrofit2.HttpException
 import java.io.IOException
@@ -39,6 +40,10 @@ class HomeViewModel : ViewModel() {
         get() = _message
 
     init {
+        getHomeStats()
+    }
+
+    fun getHomeStats() {
         userDataManager.getHomeStats()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -57,6 +62,9 @@ class HomeViewModel : ViewModel() {
                             is IOException -> {
                                 _message.postValue(MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet))
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getHomeStats()
+                                }
                             }
                             is TimeoutException -> {
                                 _message.postValue(MentorshipApplication.getContext()

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MemberProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MemberProfileViewModel.kt
@@ -13,6 +13,7 @@ import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -50,6 +51,9 @@ class MemberProfileViewModel : ViewModel() {
                             is IOException -> {
                                 message = MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet)
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getUserProfile(userId)
+                                }
                             }
                             is TimeoutException -> {
                                 message = MentorshipApplication.getContext()

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
@@ -12,6 +12,7 @@ import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -48,6 +49,9 @@ class MembersViewModel : ViewModel() {
                             is IOException -> {
                                 message = MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet)
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getUsers()
+                                }
                             }
                             is TimeoutException -> {
                                 message = MentorshipApplication.getContext()

--- a/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
@@ -13,6 +13,7 @@ import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -49,6 +50,9 @@ class ProfileViewModel: ViewModel() {
                             is IOException -> {
                                 message = MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet)
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getProfile()
+                                }
                             }
                             is TimeoutException -> {
                                 message = MentorshipApplication.getContext()

--- a/app/src/main/java/org/systers/mentorship/viewmodels/RelationViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/RelationViewModel.kt
@@ -13,6 +13,7 @@ import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.remote.datamanager.RelationDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -50,6 +51,9 @@ class RelationViewModel : ViewModel() {
                             is IOException -> {
                                 message = MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet)
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getCurrentRelationDetails()
+                                }
                             }
                             is TimeoutException -> {
                                 message = MentorshipApplication.getContext()

--- a/app/src/main/java/org/systers/mentorship/viewmodels/RequestsViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/RequestsViewModel.kt
@@ -12,6 +12,7 @@ import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.remote.datamanager.RelationDataManager
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.NetworkStateReceiver
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -48,6 +49,9 @@ class RequestsViewModel : ViewModel() {
                             is IOException -> {
                                 message = MentorshipApplication.getContext()
                                         .getString(R.string.error_please_check_internet)
+                                NetworkStateReceiver.isOnline.observeForever {
+                                    if (it) getAllMentorshipRelations()
+                                }
                             }
                             is TimeoutException -> {
                                 message = MentorshipApplication.getContext()


### PR DESCRIPTION
### Description
- Added a BroadCastReceiver -> NetworkStateReceiver
- Added observers for isOnline boolean in the ViewModels of Fragments/Activities that can upload data by itself (it would be weird if user after clicking button change password would get an error message and then it would be uploaded automatically)
- Needed to register receiver programmatically because
> Apps targeting Android 7.0 (API level 24) and higher do not receive CONNECTIVITY_ACTION broadcasts if they declare the broadcast receiver in their manifest

Fixes #419 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my phone.

### Gif:
![20191227_011101](https://user-images.githubusercontent.com/34242059/71494641-e8fef200-2848-11ea-9767-870432efa9ba.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings