### PR TITLE
[Program: GCI] Fix the overlap between text and button on Request Detail Screen

### DIFF
--- a/app/src/main/res/layout/activity_request_detail.xml
+++ b/app/src/main/res/layout/activity_request_detail.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraintLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvOtherUserName"
@@ -134,4 +139,5 @@
         app:layout_constraintVertical_bias="0.092"
         tools:text="TextView" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
### Description
Added a scroll view so that the "Delete" button doesn't overlap the displayed request details on landscape orientation.
Before:
![Screenshot_1577487253](https://user-images.githubusercontent.com/58389054/71535944-a69de980-290a-11ea-9691-3db731da9c02.png)

Fixes #558

### Type of Change:

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Tested manually.
Still, nothing is messed up on the portrait orientation:
![Screenshot_1577490109](https://user-images.githubusercontent.com/58389054/71535979-fbd9fb00-290a-11ea-9f9a-c4bbdd57ef7b.png)
here is how it works on landscape orientation:
![deletebutton2](https://user-images.githubusercontent.com/58389054/71536939-7a3b9a80-2915-11ea-8be6-a1a898fe24e0.gif)




### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules