### PR TITLE
[Program: GCI] Fix the app crash on orientation change while creating a new task

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/AddTaskFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/AddTaskFragment.kt
@@ -1,0 +1,53 @@
+package org.systers.mentorship.view.fragments
+
+import android.annotation.SuppressLint
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.EditText
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.ViewModelProviders
+import org.systers.mentorship.R
+import org.systers.mentorship.viewmodels.TasksViewModel
+
+class AddTaskFragment : DialogFragment() {
+
+    companion object {
+        /**
+         * Creates an instance of AddTaskFragment
+         */
+        fun newInstance() = AddTaskFragment()
+    }
+
+    @SuppressLint("InflateParams")
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        retainInstance = true
+        val taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
+
+        val builder = AlertDialog.Builder(context)
+        val dialogLayout = LayoutInflater.from(context).inflate(R.layout.dialog_add_task, null)
+        val editText = dialogLayout.findViewById<EditText>(R.id.etAddTask)
+
+        builder.setTitle(getString(R.string.add_new_task))
+        builder.setView(dialogLayout)
+
+        builder.setPositiveButton(getString(R.string.save)) { _, _ ->
+            val newTask: String = editText.text.toString()
+            taskViewModel.addTask(newTask)
+        }
+        builder.setNegativeButton(getString(R.string.cancel)) { dialogInterface, _ ->
+            dialogInterface.dismiss()
+        }
+
+        return builder.create()
+    }
+
+    // this prevents the dialog of being closed on orientation change
+    override fun onDestroyView() {
+        if (dialog != null && retainInstance)
+            dialog.setDismissMessage(null)
+        super.onDestroyView()
+    }
+
+}

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -43,6 +43,8 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        retainInstance = true
+
         activityCast.showProgressDialog(getString(R.string.fetching_users))
         populateView(mentorshipRelation)
         relationViewModel = ViewModelProviders.of(this).get(RelationViewModel::class.java)

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
@@ -25,7 +25,9 @@ class RelationPagerFragment : BaseFragment() {
     }
 
     private lateinit var relationViewModel: RelationViewModel
+    private var currentItem = 0
     private val activityCast by lazy { activity as MainActivity }
+    private val currentItemKey = "currentItemKey"
 
     override fun getLayoutResourceId(): Int {
         return R.layout.fragment_relation
@@ -34,12 +36,13 @@ class RelationPagerFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        currentItem = savedInstanceState?.getInt(currentItemKey) ?: 0
+
         relationViewModel = ViewModelProviders.of(this).get(RelationViewModel::class.java)
-        relationViewModel.successfulGet.observe(this, Observer {
-            successfull ->
+        relationViewModel.successfulGet.observe(this, Observer { successful ->
             activityCast.hideProgressDialog()
-            if (successfull != null) {
-                if (successfull) {
+            if (successful != null) {
+                if (successful) {
                     updateView(relationViewModel.mentorshipRelation)
                 } else {
                     view?.let {
@@ -53,6 +56,11 @@ class RelationPagerFragment : BaseFragment() {
         relationViewModel.getCurrentRelationDetails()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(currentItemKey, vpMentorshipRelation.currentItem)
+        super.onSaveInstanceState(outState)
+    }
+
     private fun updateView(mentorshipRelation: Relationship) {
         if (mentorshipRelation.mentor == null) {
             tvNoCurrentRelation.visibility = View.VISIBLE
@@ -64,6 +72,7 @@ class RelationPagerFragment : BaseFragment() {
             tlMentorshipRelation.visibility = View.VISIBLE
             vpMentorshipRelation.visibility = View.VISIBLE
             vpMentorshipRelation.adapter = RelationPagerAdapter(childFragmentManager, mentorshipRelation)
+            vpMentorshipRelation.currentItem = currentItem
             tlMentorshipRelation.setupWithViewPager(vpMentorshipRelation)
         }
     }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -42,6 +42,8 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        retainInstance = true
+
         taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
         taskViewModel.successful.observe(this, Observer {
             successful ->
@@ -74,23 +76,10 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
     }
 
     /**
-     * The function creates a dialog box through whoch new tasks can be added
+     * The function creates a dialog box through which new tasks can be added
      */
-    fun showDialog() {
-        val builder = AlertDialog.Builder(context)
-        val inflater = layoutInflater
-        builder.setTitle(appContext.getString(R.string.add_new_task))
-        val dialogLayout = inflater.inflate(R.layout.dialog_add_task, null)
-        val editText = dialogLayout.findViewById<EditText>(R.id.etAddTask)
-        builder.setView(dialogLayout)
-        builder.setPositiveButton(appContext.getString(R.string.save)) { dialogInterface, i ->
-            val newTask: String = editText.text.toString()
-            taskViewModel.addTask(newTask)
-        }
-        builder.setNegativeButton(appContext.getString(R.string.cancel)) { dialogInterface, i ->
-            dialogInterface.dismiss()
-        }
-        builder.show()
+    private fun showDialog() {
+        AddTaskFragment.newInstance().show(fragmentManager, null)
     }
 
     private val markTask: (Int) -> Unit = { taskId ->


### PR DESCRIPTION
### Description
- Fixed app crash by adding `retainInstance = true` (we could also define a constructor that has no parameters and use Bundle to save the params, but this would be more code)
- Added `AddTaskFragment` in order to keep the dialog on screen rotation

Fixes #221 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The code was tested on my phone.

### Gif:
![20191228_030342](https://user-images.githubusercontent.com/34242059/71537701-22566100-2920-11ea-894c-25e3507fdad2.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings