### PR TITLE
[Program:GCI] Logout a user when JWT expires

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -11,6 +11,7 @@ import kotlinx.android.synthetic.main.activity_login.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.Login
 import org.systers.mentorship.viewmodels.LoginViewModel
+import java.lang.Exception
 
 /**
  * This activity will let the user to login using username/email and password.
@@ -60,6 +61,19 @@ class LoginActivity : BaseActivity() {
             }
             false
         }
+        //message when session expired
+        try {
+            val bundle = intent.extras
+            val toastTokenExpired = bundle.getInt("toastTokenExpired")
+            if(toastTokenExpired == 1){
+                Snackbar.make(
+                        getRootView(),
+                        "Session expired, please login again",
+                        Snackbar.LENGTH_LONG
+                ).show()
+            }
+        }
+        catch (exception: Exception){}
     }
 
     private fun validateCredentials() : Boolean {


### PR DESCRIPTION
### Description
Code to log out a user when JWT expires, take her to login screen and to display toast message "Session expired, please login again".

Fixes #556 

#### Working
- okHttpClient authenticator used for clearing tokens in Preference Manager when 401 response is received. It also takes user to LoginActivity.
- LoginActivity shows snackbar message "Session expired, please login again".


### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Steps to mimic expired token
1. Start backend on localhost
2. Change URL in BaseUrl.kt to **"http://10.0.2.2:5000"**
```kotlin
    val apiBaseUrl: String
        get() = if (BuildConfig.DEBUG) {
            //"$PROTOCOL_HTTPS$DEVELOPMENT_URL$EB_REGION"
            "http://10.0.2.2:5000"
        }
```
3. Run app on **emulator** and login. Any other method can also be used but app must be linked to localhost backend.
4. Change computer time so that token expires (token duration is 1 week).
![task50_1](https://user-images.githubusercontent.com/50169911/71763023-042ec900-2efd-11ea-981c-ab20098768e0.png)

5. Click any navigation button in app so that backend API is triggered. 401 response will cause user to log out.
![task50_2](https://user-images.githubusercontent.com/50169911/71762991-aef2b780-2efc-11ea-9697-a1bb44a3edc1.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules