### PR TITLE
[Program:GCI] Logout user when JWT expires.

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
@@ -39,6 +39,7 @@ class ApiManager {
         val okHttpClient = OkHttpClient.Builder()
                 .addInterceptor(interceptor)
                 .addInterceptor(CustomInterceptor())
+                .authenticator(TokenAuthenticator())
                 .build()
 
         val retrofit = Retrofit.Builder()

--- a/app/src/main/java/org/systers/mentorship/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/TokenAuthenticator.kt
@@ -1,0 +1,29 @@
+package org.systers.mentorship.remote
+
+import android.widget.Toast
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.utils.Constants.STATUS_CODE_UNAUTHORISED
+import org.systers.mentorship.view.activities.SettingsActivity.Companion.logout
+
+/**
+ * Represents a custom HTTP Requests Authenticator.
+ * */
+class TokenAuthenticator : Authenticator {
+
+    override fun authenticate(route: Route, response: Response): Request? {
+        /**
+         * If the user's token has expired, it will logout the user from the app.
+         * */
+        if ( response.code() == STATUS_CODE_UNAUTHORISED ) {
+            logout()
+            val context = MentorshipApplication.getContext()
+            Toast.makeText(context, R.string.token_expired, Toast.LENGTH_LONG).show()
+        }
+        return null
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/utils/Constants.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Constants.kt
@@ -9,4 +9,5 @@ object Constants {
     const val RELATIONSHIP_EXTRA = "relationship_extra"
     const val DELETE_REQUEST_RESULT_ID = 1000
     const val REQUEST_ID = "request_id"
+    const val STATUS_CODE_UNAUTHORISED = 401
 }

--- a/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
@@ -3,14 +3,31 @@ package org.systers.mentorship.view.activities
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import androidx.core.app.ActivityCompat.finishAffinity
 import kotlinx.android.synthetic.main.activity_settings.*
+import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.PreferenceManager
 import org.systers.mentorship.view.fragments.ChangePasswordFragment
 
 class SettingsActivity : BaseActivity() {
 
-    private val preferenceManager: PreferenceManager = PreferenceManager()
+    companion object {
+        /**
+         * This method is used to logout the user from the app.
+         * */
+        fun logout() {
+            val context = MentorshipApplication.getContext()
+
+            PreferenceManager().clear()
+
+            val intent = Intent(context, LoginActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            context.applicationContext.startActivity(intent)
+            finishAffinity(SettingsActivity())
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,9 +42,7 @@ class SettingsActivity : BaseActivity() {
             builder.setTitle(R.string.confirm_logout)
             builder.setMessage(R.string.confirm_logout_msg)
             builder.setPositiveButton(R.string.logout) { _, _ ->
-                preferenceManager.clear()
-                startActivity(Intent(this, LoginActivity::class.java))
-                finishAffinity()
+                logout()
             }
             builder.setNegativeButton(R.string.cancel) { dialog, _ ->
                 dialog.cancel()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,5 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="token_expired">Session token expired! Login again to continue.</string>
 </resources>


### PR DESCRIPTION
### Description
Added this new feature which logouts the user when JWT token expires.

Fixes #556 

### Type of Change:
**Delete irrelevant options.**

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
This has been tested manually by me.
1. Run mentorship-backend project locally on the system.
2. Change baseurl in BaseUrl.kt file to the localhost url, `http://localhost:5000`, where the backend project is running
3. Run mentorship-android on the emulator.
4. Log In the user.
5. Change the date on the system to any date ,15 days after the current date.
6. Switch the page on the app to profile page ( or any other page).
7. The user is logged out of the app, since JWT token is expired.

![20200104_155527](https://user-images.githubusercontent.com/58501114/71764663-ae641c00-2f10-11ea-975c-d1ca1e27df42.gif)




### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules