### PR TITLE
Login Page toast/snackbar now visible.

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -1,11 +1,13 @@
 package org.systers.mentorship.view.activities
 
+import android.content.Context
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_login.*
 import org.systers.mentorship.R
@@ -45,7 +47,8 @@ class LoginActivity : BaseActivity() {
         })
 
         btnLogin.setOnClickListener {
-           login()
+            hideKeyboard()
+            login()
         }
 
         btnSignUp.setOnClickListener {
@@ -77,6 +80,14 @@ class LoginActivity : BaseActivity() {
             tiPassword.error = null
         }
         return validCredentials
+    }
+
+    /**
+     * This method closes the virtual keyboard on the device.
+     * */
+    private fun hideKeyboard(){
+        var inputMethodManager:InputMethodManager= getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(if(null==currentFocus) null else currentFocus.windowToken,InputMethodManager.HIDE_NOT_ALWAYS)
     }
 
     private fun login() {


### PR DESCRIPTION
### Description
The login page's error messages are now visible , earlier the messages were hidden by the keyboard over them but it's been corrected.

Fixes # [ISSUE]
#388 

### Type of Change:
**Delete irrelevant options.**

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This has been tested by me on my device. (works on emulator as well).
![20200111_043746](https://user-images.githubusercontent.com/58501114/72192656-869f1780-342c-11ea-8ac3-65b6631aca9b.gif)




### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules