### PR TITLE
[Program:GCI] Retain values in sign up page when orientation changed

### DIFF
--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -37,6 +37,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tvSignUp">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiNameEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textPersonName" />
@@ -53,6 +54,7 @@
             app:layout_constraintTop_toBottomOf="@id/tiName">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiUsernameEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
@@ -69,6 +71,7 @@
             app:layout_constraintTop_toBottomOf="@id/tiUsername">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiEmailEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
@@ -86,6 +89,7 @@
             app:passwordToggleEnabled="true">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiPasswordEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textPassword" />
@@ -103,6 +107,7 @@
             app:passwordToggleEnabled="true">
 
             <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tiConfirmPasswordEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:inputType="textPassword" />


### PR DESCRIPTION
### Description
Values were getting lost when screen orientation was changed in sign-up page. 'android:id' added to every TextInputEditText so that values are retained.

**Reference**: https://stackoverflow.com/questions/29208086/save-the-position-of-scrollview-when-the-orientation-changes

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Issue earlier
![task52_1](https://user-images.githubusercontent.com/50169911/71789224-ae1e6a80-304f-11ea-888c-0d16f633af58.gif)

2. Fix
![task52_2](https://user-images.githubusercontent.com/50169911/71789225-ae1e6a80-304f-11ea-940e-275ef799685b.gif)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules