### PR TITLE
[Program:GCI] Disable send request button if the person is not available to be mentor or mentee

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -38,6 +38,12 @@ class MemberProfileActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     setUserProfile(memberProfileViewModel.userProfile)
+                    // disable button if not available as mentor and mentee
+                    if (!memberProfileViewModel.userProfile.needsMentoring!! &&
+                            !memberProfileViewModel.userProfile.isAvailableToMentor!!){
+                        btnSendRequest?.isEnabled = false
+                        btnSendRequest?.isClickable = false
+                    }
                 } else {
                     Snackbar.make(getRootView(), memberProfileViewModel.message, Snackbar.LENGTH_LONG)
                             .show()


### PR DESCRIPTION
### Description
Disable send request button if the person is not available to be mentor or mentee.

Fixes #555 

#### Working
```userProfile.needsMentoring``` and ```userProfile.isAvailableToMentor``` used to find if person is available. If not then ```isEnabled``` and ```isClickable``` for **btnSendRequest** set to false.

Reference: https://stackoverflow.com/questions/55645273/how-to-disable-a-button-in-kotlin/55645526

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. Before: Button is clickable but cannot send request
![task54_1](https://user-images.githubusercontent.com/50169911/71833837-d18af900-30d3-11ea-81f5-e15e1ac6e617.gif)

2. After: Button works when person is available
![task54_2](https://user-images.githubusercontent.com/50169911/71833834-d18af900-30d3-11ea-8879-122fb03bccb0.gif)

3. After: Button disabled when user is unavailable
![task54_3](https://user-images.githubusercontent.com/50169911/71833832-d0f26280-30d3-11ea-8390-ced69bd67f6c.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules