### PR TITLE
[Program: GCI] Disable send request button if the person is not available to be mentor and mentee

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -99,6 +99,8 @@ class MemberProfileActivity : BaseActivity() {
                 tvUsername, getString(R.string.username), user.username)
         setTextViewStartingWithBoldSpan(
                 tvSlackUsername, getString(R.string.slack_username), user.slackUsername)
+        if (!user.isAvailableToMentor!! && !user.needsMentoring!!)
+            btnSendRequest.isEnabled = false
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Description
disabled send request button for member profile not available to mentor/for mentoring

Fixes #555 

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I tested the build on my smartphone and on an emulator. Here's a screenshot
![Screenshot_1578339443](https://user-images.githubusercontent.com/29257061/71843676-6c8ecd80-30ea-11ea-9d1f-6aecdd2b916f.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules