### PR TITLE
[Program:GCI] Prevent sending multiple similar mentorship requests

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="end_date_format">dd/mm/YYYY</string>
     <string name="no_current_mentorship_relation">You are not in a current mentorship relation.</string>
     <string name="notes_empty_error">Notes cannot be empty</string>
+    <string name="similar_request_error">Similar request was already sent</string>
     <string name="available_to_be_mentor_mentee">Available to be a:</string>
     <string name="settings">Settings</string>
     <string name="error_name_too_short">Name should have a minimum of %1$d characters</string>


### PR DESCRIPTION
### Description
Prevent user from sending multiple mentor/mentee requests to the same person

#### Working
- Conditions for failure: receiver, mentor/mentee field, end date are same
- Make **GET /mentorship_relations** API call, add observer and and filter the list for past relations. See if similar field is present. If yes then do not send mentorship request. Display error message "Similar request was already sent".
- Helper function **findReceiver()** to find who is receiver

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. Disable duplicate request
![task56_1](https://user-images.githubusercontent.com/50169911/71899113-128d1700-3181-11ea-8173-41cc1e9331c4.gif)

2. Allow new requests
![task56_2](https://user-images.githubusercontent.com/50169911/71899112-128d1700-3181-11ea-9e5f-f4b18e345fbb.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules