### PR TITLE
[Program:GCI] Reduce network operations using okhttp3 cache

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/ApiManager.kt
@@ -1,7 +1,9 @@
 package org.systers.mentorship.remote
 
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.remote.services.AuthService
 import org.systers.mentorship.remote.services.RelationService
 import org.systers.mentorship.remote.services.TaskService
@@ -9,9 +11,10 @@ import org.systers.mentorship.remote.services.UserService
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
 
 /**
- * A class that represents API Manager. It encapsulates three services: authentication, relation and user.
+ * A class that represents API Manager. It encapsulates tree services: authentication, relation and user.
  */
 class ApiManager {
 
@@ -36,9 +39,18 @@ class ApiManager {
         val interceptor = HttpLoggingInterceptor()
         interceptor.level = HttpLoggingInterceptor.Level.BODY
 
+        /*
+        Create cache to store server responses and reduce number of API calls. For this an okhttp3
+        network interceptor is used.
+         */
+        val httpCacheDirectory = File(MentorshipApplication.getContext().cacheDir, "http-cache")
+        val cacheSize: Long = 5 * 1024 * 1024 // 5 MiB
+        val cache = Cache(httpCacheDirectory, cacheSize)
         val okHttpClient = OkHttpClient.Builder()
                 .addInterceptor(interceptor)
                 .addInterceptor(CustomInterceptor())
+                .addNetworkInterceptor(CacheInterceptor())
+                .cache(cache)
                 .build()
 
         val retrofit = Retrofit.Builder()

--- a/app/src/main/java/org/systers/mentorship/remote/CacheInterceptor.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/CacheInterceptor.kt
@@ -1,0 +1,24 @@
+package org.systers.mentorship.remote
+
+import okhttp3.CacheControl
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class CacheInterceptor : Interceptor {
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+
+        val cacheControl = CacheControl.Builder()
+                .maxAge(30, TimeUnit.MINUTES) // 30 minutes cache
+                .build()
+
+        return response.newBuilder()
+                .removeHeader("Pragma")
+                .removeHeader("Cache-Control")
+                .header("Cache-Control", cacheControl.toString())
+                .build()
+    }
+}


### PR DESCRIPTION
### Description
Number of network operations reduced using okhttp3 cache. If response data exists in cache, API call is not made.

#### Working
- Network interceptor CacheInterceptor() added to okHttpClient.
- 5MB cache with 30 minute duration

**Reference**: https://stackoverflow.com/questions/49453564/how-to-cache-okhttp-response-from-web-server

### Type of Change:
- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
#### Screen grab


#### Logs
Two requests were made to /home endpoint at different times. The response header containing server's time is the same (09:46:27 GMT)

```
2020-01-08 15:20:20.016 31945-2449/org.systers.mentorship D/OkHttp: <-- 200 OK http://systers-mentorship-dev.eu-central-1.elasticbeanstalk.com/home (6ms)
2020-01-08 15:20:20.016 31945-2449/org.systers.mentorship D/OkHttp: Date: Wed, 08 Jan 2020 09:46:27 GMT
```

```
2020-01-08 15:21:50.675 31945-2546/org.systers.mentorship D/OkHttp: <-- 200 OK http://systers-mentorship-dev.eu-central-1.elasticbeanstalk.com/home (7ms)
2020-01-08 15:21:50.675 31945-2546/org.systers.mentorship D/OkHttp: Date: Wed, 08 Jan 2020 09:46:27 GMT
```

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules