### PR TITLE
[Program: GCI] Add transition animations

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
@@ -1,7 +1,6 @@
 package org.systers.mentorship.view.activities
 
 import android.content.Intent
-import android.content.res.Resources
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -43,6 +42,12 @@ class AboutActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         onBackPressed()
         return true
+    }
+
+    // need to overwrite finish() function for transition animation
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.anim_stop, R.anim.anim_slide_from_left)
     }
 
 }

--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -36,6 +36,7 @@ class LoginActivity : BaseActivity() {
                             .show()
                     intent = Intent(this, MainActivity::class.java)
                     startActivity(intent)
+                    overridePendingTransition(R.anim.anim_slide_down,  R.anim.anim_stop)
                     finish()
                 } else {
                     Snackbar.make(getRootView(), loginViewModel.message, Snackbar.LENGTH_LONG)
@@ -51,7 +52,7 @@ class LoginActivity : BaseActivity() {
         btnSignUp.setOnClickListener {
             intent = Intent(this, SignUpActivity::class.java)
             startActivity(intent)
-            finish()
+            overridePendingTransition(R.anim.anim_slide_from_right,  R.anim.anim_stop)
         }
 
         tiPassword.editText?.setOnEditorActionListener { _, actionId, _ ->

--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.view.activities
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.PersistableBundle
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import android.view.Menu
 import android.view.MenuItem
@@ -79,6 +78,7 @@ class MainActivity: BaseActivity() {
             when (item.itemId) {
                 R.id.menu_settings -> {
                     startActivity(Intent(this, SettingsActivity::class.java))
+                    overridePendingTransition(R.anim.anim_slide_down,  R.anim.anim_stop)
                     true
                 }
                 else -> false

--- a/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SettingsActivity.kt
@@ -41,6 +41,7 @@ class SettingsActivity : BaseActivity() {
         }
         tvAbout.setOnClickListener {
             startActivity(Intent(baseContext,AboutActivity::class.java))
+            overridePendingTransition(R.anim.anim_slide_from_right,  R.anim.anim_stop)
         }
     }
 
@@ -48,4 +49,11 @@ class SettingsActivity : BaseActivity() {
         onBackPressed()
         return true
     }
+
+    // need to overwrite finish() function for transition animation
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.anim_stop,  R.anim.anim_slide_up)
+    }
+
 }

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -1,6 +1,5 @@
 package org.systers.mentorship.view.activities
 
-import android.content.Intent
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.widget.Toast
@@ -37,7 +36,7 @@ class SignUpActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     Toast.makeText(this, signUpViewModel.message, Toast.LENGTH_LONG).show()
-                    navigateToLoginActivity()
+                    finish()
                 } else {
                     Snackbar.make(getRootView(), signUpViewModel.message, Snackbar.LENGTH_LONG)
                             .show()
@@ -64,7 +63,7 @@ class SignUpActivity : BaseActivity() {
             }
         }
         btnLogin.setOnClickListener {
-            navigateToLoginActivity()
+            finish()
         }
         cbTC.setOnCheckedChangeListener { _, b ->
             btnSignUp.isEnabled = b
@@ -117,9 +116,14 @@ class SignUpActivity : BaseActivity() {
         return isValid
     }
 
-    private fun navigateToLoginActivity() {
-        intent = Intent(this, LoginActivity::class.java)
-        startActivity(intent)
+    override fun onBackPressed() {
         finish()
     }
+
+    // need to overwrite finish() function for transition animation
+    override fun finish() {
+        super.finish()
+        overridePendingTransition(R.anim.anim_stop, R.anim.anim_slide_from_left)
+    }
+
 }

--- a/app/src/main/res/anim/anim_slide_down.xml
+++ b/app/src/main/res/anim/anim_slide_down.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime">
+    <translate
+        android:fromYDelta="-100%p"
+        android:toYDelta="0" />
+</set>

--- a/app/src/main/res/anim/anim_slide_from_left.xml
+++ b/app/src/main/res/anim/anim_slide_from_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime">
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="100%p" />
+</set>

--- a/app/src/main/res/anim/anim_slide_from_right.xml
+++ b/app/src/main/res/anim/anim_slide_from_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime">
+    <translate
+        android:fromXDelta="100%p"
+        android:toXDelta="0" />
+</set>

--- a/app/src/main/res/anim/anim_slide_up.xml
+++ b/app/src/main/res/anim/anim_slide_up.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime">
+    <translate
+        android:fromYDelta="0"
+        android:toYDelta="-100%p" />
+</set>

--- a/app/src/main/res/anim/anim_stop.xml
+++ b/app/src/main/res/anim/anim_stop.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="@android:integer/config_mediumAnimTime"
+    android:fromYDelta="0"
+    android:toYDelta="0" />


### PR DESCRIPTION
### Description
- Added transition animations for main activities such as Login, SIgnUp, Main and Settings activities
- I thought of all activities in "layers" so on the bottom there are Login and SignUp pages, then in the middle the MainActivity and on the top the SettingsActivity. And in order to show that I used `slide-down` and `slide-up` animations.
- For screens that are on the same layer, I've used `slide-from-right` or sli`de-from-left` animations, so, for example, in the Login and SignUp pages 
- I've changed a bit LoginActivity so that it doesn't finish launching the SignUp page as the user still will be returned back to the Login page and as it would be logical if the user, pressing hte back button, would be returned back to login screen instead of finishing the app. This also helps us to save the user's data on the Login page.
  -> see the gif
- I didn't touch the Member Profile and Send request pages as they need a redesign and there was a task/issue for that, so it should be implemented there (transition anim with shared views -> profile image)

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my smartphone.

### Gif:
![20200108-215207](https://user-images.githubusercontent.com/34242059/72016290-cc5cb400-3263-11ea-8239-19378b31932c.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings