### PR TITLE
[Program: GCI] Fix overlap between the Mentorship Logo and Username field

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -99,3 +103,4 @@
         app:layout_constraintVertical_bias="0.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
## Description

I have added the scroll view for the landscape orientation of the login page. In this view, the overlapping of section is fixed, and the sign up button is able to show.

Fixes #176 

## Type of Change:

- User Interface

## How Has This Been Tested?

I run this layout on an Android Studio Emulator (Pixel 3 XL API 29). Below is a screenshot:
![giphy](https://user-images.githubusercontent.com/59384702/72124177-c8976300-3331-11ea-8e2c-e3e2f8272b32.gif)

## Checklist:

My PR follows the style guidelines of this project
I have performed a self-review of my own code or materials
I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
I have made corresponding changes to the documentation
Any dependent changes have been merged
I have written Kotlin Docs whenever is applicable