### PR TITLE
text cutting bottomNaviation

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="generic_28sp">28sp</dimen>
+    <dimen name="design_bottom_navigation_active_text_size" tools:override="true">12sp</dimen>
 </resources>


### PR DESCRIPTION
### Description
By default on using google bottom navigation view on select text get enlarge which leads in cutting of text .

Fixes #494 

### Type of Change:
change in dimens.xml where i override the default behaviour.

### How Has This Been Tested?
- Screnshoot below
   - Before
![errmem](https://user-images.githubusercontent.com/33172321/72225960-7feddd00-35b1-11ea-8ec1-2b0ca5e6bb27.jpg)
   - after
![fixmem](https://user-images.githubusercontent.com/33172321/72225972-9d22ab80-35b1-11ea-8aa6-95a5ee5231bc.jpg)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes