### PR TITLE
fix:cancel button and note text disorientation(on rotation)

### DIFF
--- a/app/src/main/res/layout/fragment_relation_pager.xml
+++ b/app/src/main/res/layout/fragment_relation_pager.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android" >
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -117,3 +120,4 @@
         app:layout_constraintVertical_bias="0.056" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
### Description
On rotation of device from portrait to landscape the note text and cancel button overlap in rotation fragment .

Fixes #492 

### Type of Change:
changes fragment_relation_pager.xml added nestes scroll view.

### How Has This Been Tested?
Tested on device
- GIF
 
![disorientation](https://user-images.githubusercontent.com/33172321/72298590-826d3700-3684-11ea-8301-7f09569e88c1.gif)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes