### PR TITLE
[Program: GCI] ViewModels initialization using lazy delegated properties

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,8 @@ dependencies {
 
     implementation Dependencies.lifecycle_extensions
     implementation Dependencies.lifecycle_viewmodel
+
+    implementation Dependencies.core_ktx
+    implementation Dependencies.activityKtx
+    implementation Dependencies.fragmentKtx
 }

--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -1,12 +1,12 @@
 package org.systers.mentorship.view.activities
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
+import androidx.activity.viewModels
 import kotlinx.android.synthetic.main.activity_login.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.Login
@@ -17,7 +17,7 @@ import org.systers.mentorship.viewmodels.LoginViewModel
  */
 class LoginActivity : BaseActivity() {
 
-    private lateinit var loginViewModel: LoginViewModel
+    private val loginViewModel: LoginViewModel by viewModels()
 
     private lateinit var username: String
     private lateinit var password: String
@@ -26,7 +26,6 @@ class LoginActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
-        loginViewModel = ViewModelProviders.of(this).get(LoginViewModel::class.java)
         loginViewModel.successful.observe(this, Observer {
             successful ->
             hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -1,11 +1,11 @@
 package org.systers.mentorship.view.activities
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.view.MenuItem
+import androidx.activity.viewModels
 import kotlinx.android.synthetic.main.activity_member_profile.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
@@ -19,7 +19,7 @@ import org.systers.mentorship.viewmodels.MemberProfileViewModel
  */
 class MemberProfileActivity : BaseActivity() {
 
-    private lateinit var memberProfileViewModel: MemberProfileViewModel
+    private val memberProfileViewModel: MemberProfileViewModel by viewModels()
     private lateinit var userProfile: User
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,7 +31,6 @@ class MemberProfileActivity : BaseActivity() {
 
         val userId = intent.getIntExtra(Constants.MEMBER_USER_ID, 0)
 
-        memberProfileViewModel = ViewModelProviders.of(this).get(MemberProfileViewModel::class.java)
         memberProfileViewModel.successful.observe(this, Observer {
             successful ->
             hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/RequestDetailActivity.kt
@@ -1,7 +1,6 @@
 package org.systers.mentorship.view.activities
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.text.method.ScrollingMovementMethod
@@ -15,6 +14,7 @@ import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.utils.*
 import org.systers.mentorship.viewmodels.RequestDetailViewModel
 import android.content.Intent
+import androidx.activity.viewModels
 import org.systers.mentorship.view.fragments.RequestPagerFragment
 
 /**
@@ -22,7 +22,7 @@ import org.systers.mentorship.view.fragments.RequestPagerFragment
  */
 class RequestDetailActivity: BaseActivity() {
 
-    private lateinit var requestDetailViewModel: RequestDetailViewModel
+    private val requestDetailViewModel: RequestDetailViewModel by viewModels()
 
     private val mentorshipRelationResponse by lazy {
         intent.getParcelableExtra<Relationship>(Constants.RELATIONSHIP_EXTRA)
@@ -137,7 +137,6 @@ class RequestDetailActivity: BaseActivity() {
     }
 
     private fun setObservables(relationResponse: Relationship) {
-        requestDetailViewModel  = ViewModelProviders.of(this).get(RequestDetailViewModel::class.java)
         requestDetailViewModel.successful.observe(this, Observer {
             successful ->
             hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SendRequestActivity.kt
@@ -2,7 +2,6 @@ package org.systers.mentorship.view.activities
 
 import android.app.DatePickerDialog
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.text.SpannableStringBuilder
@@ -10,6 +9,7 @@ import android.text.TextUtils
 import android.view.MenuItem
 import android.widget.DatePicker
 import android.widget.Toast
+import androidx.activity.viewModels
 import kotlinx.android.synthetic.main.activity_send_request.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.RelationshipRequest
@@ -31,7 +31,7 @@ class SendRequestActivity: BaseActivity() {
         const val OTHER_USER_NAME_INTENT_EXTRA = "OTHER_USER_NAME_INTENT_EXTRA"
     }
 
-    private lateinit var sendRequestViewModel: SendRequestViewModel
+    private val sendRequestViewModel: SendRequestViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -116,7 +116,6 @@ class SendRequestActivity: BaseActivity() {
     }
 
     private fun setObservables() {
-        sendRequestViewModel  = ViewModelProviders.of(this).get(SendRequestViewModel::class.java)
         sendRequestViewModel.successful.observe(this, Observer {
             successful ->
             hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -4,8 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_sign_up.*
 import org.systers.mentorship.R
@@ -18,7 +18,7 @@ import org.systers.mentorship.viewmodels.SignUpViewModel
  */
 class SignUpActivity : BaseActivity() {
 
-    private lateinit var signUpViewModel: SignUpViewModel
+    private val signUpViewModel: SignUpViewModel by viewModels()
 
     private lateinit var name: String
     private lateinit var username: String
@@ -31,7 +31,6 @@ class SignUpActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sign_up)
-        signUpViewModel = ViewModelProviders.of(this).get(SignUpViewModel::class.java)
         signUpViewModel.successful.observe(this, Observer { successful ->
             hideProgressDialog()
             if (successful != null) {

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -2,13 +2,13 @@ package org.systers.mentorship.view.fragments
 
 import android.app.Dialog
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Toast
+import androidx.fragment.app.viewModels
 import kotlinx.android.synthetic.main.fragment_change_password.view.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.ChangePassword
@@ -26,14 +26,13 @@ class ChangePasswordFragment : DialogFragment() {
         fun newInstance() = ChangePasswordFragment()
     }
 
-    private lateinit var changePasswordViewModel: ChangePasswordViewModel
+    private val changePasswordViewModel: ChangePasswordViewModel by viewModels()
     private lateinit var changePasswordView: View
     private lateinit var currentPassword: String
     private lateinit var newPassword: String
     private lateinit var confirmPassword: String
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        changePasswordViewModel = ViewModelProviders.of(this).get(ChangePasswordViewModel::class.java)
         changePasswordViewModel.successfulUpdate.observe(this, Observer { successful ->
 
             if (successful != null) {

--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -3,7 +3,6 @@ package org.systers.mentorship.view.fragments
 
 import android.app.Dialog
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.appcompat.app.AlertDialog
@@ -13,6 +12,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
 import org.systers.mentorship.R
 import org.systers.mentorship.databinding.FragmentEditProfileBinding
 import org.systers.mentorship.models.User
@@ -36,13 +36,12 @@ class EditProfileFragment: DialogFragment() {
         }
     }
 
-    private lateinit var profileViewModel: ProfileViewModel
+    private val profileViewModel: ProfileViewModel by viewModels()
     private lateinit var editProfileBinding: FragmentEditProfileBinding
 
     private lateinit var currentUser: User
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        profileViewModel = ViewModelProviders.of(activity!!).get(ProfileViewModel::class.java)
         profileViewModel.successfulUpdate.observe(this, Observer { successful ->
             (activity as MainActivity).hideProgressDialog()
             if (successful != null) {
@@ -55,7 +54,7 @@ class EditProfileFragment: DialogFragment() {
                 }
             }
         })
-        dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        dialog?.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         isCancelable = false
         return inflater.inflate(R.layout.fragment_edit_profile, container, false)
     }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
@@ -22,7 +22,7 @@ import org.systers.mentorship.viewmodels.HomeViewModel
  */
 class HomeFragment : BaseFragment() {
 
-    private lateinit var homeViewModel: HomeViewModel
+    private val homeViewModel: HomeViewModel by viewModels()
     private lateinit var binding: FragmentHomeBinding
     private lateinit var achievementsAdapter: AchievementsAdapter
 
@@ -57,7 +57,6 @@ class HomeFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        homeViewModel = ViewModelProviders.of(this).get(HomeViewModel::class.java)
 
         with(homeViewModel) {
             userStats.observe(viewLifecycleOwner, Observer { stats ->

--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -1,12 +1,12 @@
 package org.systers.mentorship.view.fragments
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
+import androidx.fragment.app.viewModels
 import kotlinx.android.synthetic.main.fragment_members.*
 import org.systers.mentorship.R
 import org.systers.mentorship.utils.Constants
@@ -27,14 +27,13 @@ class MembersFragment: BaseFragment() {
         fun newInstance() = MembersFragment()
     }
 
-    private lateinit var membersViewModel: MembersViewModel
+    private val membersViewModel: MembersViewModel by viewModels()
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_members
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        membersViewModel = ViewModelProviders.of(this).get(MembersViewModel::class.java)
         membersViewModel.successful.observe(this, Observer {
             successful ->
             (activity as MainActivity).hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -1,11 +1,11 @@
 package org.systers.mentorship.view.fragments
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.view.*
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
 import org.systers.mentorship.R
 import org.systers.mentorship.databinding.FragmentProfileBinding
 import org.systers.mentorship.viewmodels.ProfileViewModel
@@ -24,7 +24,7 @@ class ProfileFragment : BaseFragment() {
     }
 
     private lateinit var fragmentProfileBinding: FragmentProfileBinding
-    private lateinit var profileViewModel: ProfileViewModel
+    private val profileViewModel: ProfileViewModel by viewModels()
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_profile
 
@@ -38,7 +38,6 @@ class ProfileFragment : BaseFragment() {
 
         setHasOptionsMenu(true)
 
-        profileViewModel = ViewModelProviders.of(activity!!).get(ProfileViewModel::class.java)
         profileViewModel.successfulGet.observe(this, Observer {
             successful ->
             baseActivity.hideProgressDialog()
@@ -63,7 +62,7 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
+                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager!!,
                         getString(R.string.fragment_title_edit_profile))
                 true
             }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -3,12 +3,12 @@ package org.systers.mentorship.view.fragments
 
 import android.annotation.SuppressLint
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.text.method.ScrollingMovementMethod
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.viewModels
 import kotlinx.android.synthetic.main.fragment_relation_pager.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
@@ -31,7 +31,7 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
         val TAG = RelationFragment::class.java.simpleName
     }
 
-    private lateinit var relationViewModel: RelationViewModel
+    private val relationViewModel: RelationViewModel by viewModels()
     private val activityCast by lazy { activity as MainActivity }
 
     private val alertDialog by lazy { activity?.let { AlertDialog.Builder(it) } }
@@ -45,7 +45,6 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
 
         activityCast.showProgressDialog(getString(R.string.fetching_users))
         populateView(mentorshipRelation)
-        relationViewModel = ViewModelProviders.of(this).get(RelationViewModel::class.java)
 
         relationViewModel.successfulCancel.observe(this, Observer { successful ->
             activityCast.hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationPagerFragment.kt
@@ -1,10 +1,10 @@
 package org.systers.mentorship.view.fragments
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
 import android.view.View
+import androidx.fragment.app.viewModels
 import kotlinx.android.synthetic.main.fragment_relation.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
@@ -24,7 +24,7 @@ class RelationPagerFragment : BaseFragment() {
         fun newInstance() = RelationPagerFragment()
     }
 
-    private lateinit var relationViewModel: RelationViewModel
+    private val relationViewModel: RelationViewModel by viewModels()
     private val activityCast by lazy { activity as MainActivity }
 
     override fun getLayoutResourceId(): Int {
@@ -34,7 +34,6 @@ class RelationPagerFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        relationViewModel = ViewModelProviders.of(this).get(RelationViewModel::class.java)
         relationViewModel.successfulGet.observe(this, Observer {
             successfull ->
             activityCast.hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/fragments/RequestsFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RequestsFragment.kt
@@ -1,8 +1,8 @@
 package org.systers.mentorship.view.fragments
 
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
+import androidx.fragment.app.viewModels
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_requests.*
 import org.systers.mentorship.R
@@ -25,7 +25,7 @@ class RequestsFragment : BaseFragment() {
         val TAG = RelationFragment::class.java.simpleName
     }
 
-    private lateinit var requestsViewModel: RequestsViewModel
+    private val requestsViewModel: RequestsViewModel by viewModels()
 
     private val activityCast by lazy { activity as MainActivity }
 
@@ -34,7 +34,6 @@ class RequestsFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        requestsViewModel = ViewModelProviders.of(this).get(RequestsViewModel::class.java)
         requestsViewModel.successful.observe(this, Observer {
             successful ->
             activityCast.hideProgressDialog()

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -2,11 +2,11 @@ package org.systers.mentorship.view.fragments
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.widget.EditText
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_mentorship_tasks.*
@@ -35,14 +35,13 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
 
     val appContext = MentorshipApplication.getContext()
 
-    private lateinit var taskViewModel: TasksViewModel
+    private val taskViewModel: TasksViewModel by viewModels()
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_mentorship_tasks;
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
         taskViewModel.successful.observe(this, Observer {
             successful ->
             if (successful != null) {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,6 +26,10 @@ object Versions {
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
 
+    const val coreKtx = "1.1.0"
+    const val activityKtx = "1.0.0"
+    const val fragmentKtx = "1.1.0"
+
 }
 
 /**
@@ -53,4 +57,8 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+
+    const val core_ktx = "androidx.core:core-ktx:${Versions.coreKtx}"
+    const val activityKtx = "androidx.activity:activity-ktx:${Versions.activityKtx}"
+    const val fragmentKtx = "androidx.fragment:fragment-ktx:${Versions.fragmentKtx}"
 }


### PR DESCRIPTION
### Description
All `ViewModel`s are now obtained `by viewModels()` from Android Fragment KTX.

[Task link](https://codein.withgoogle.com/dashboard/task-instances/6133461849473024/)

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I tested every screen manually on the emulator. It's a small change which neither affect nor change anything, so no gifs this time.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes