### PR TITLE
[Program:GCI]: Retain values when orientation changed in the Sign Up page

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -28,6 +28,26 @@ class SignUpActivity : BaseActivity() {
     private var isAvailableToMentor: Boolean = false
     private var needsMentoring: Boolean = false
 
+    override fun onSaveInstanceState(outState: Bundle?) {
+        super.onSaveInstanceState(outState)
+
+        outState?.putCharSequence("name", tiName.editText?.text.toString())
+        outState?.putCharSequence("userName", tiUsername.editText?.text.toString())
+        outState?.putCharSequence("email", tiEmail.editText?.text.toString())
+        outState?.putCharSequence("password", tiPassword.editText?.text.toString())
+        outState?.putCharSequence("confirmedPassword", tiConfirmPassword.editText?.text.toString())
+    }
+    
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+
+        tiName.editText?.setText(savedInstanceState?.getCharSequence("name"))
+        tiUsername.editText?.setText(savedInstanceState?.getCharSequence("userName"))
+        tiEmail.editText?.setText(savedInstanceState?.getCharSequence("email"))
+        tiPassword.editText?.setText(savedInstanceState?.getCharSequence("password"))
+        tiConfirmPassword.editText?.setText(savedInstanceState?.getCharSequence("confirmedPassword"))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sign_up)
@@ -69,6 +89,7 @@ class SignUpActivity : BaseActivity() {
         cbTC.setOnCheckedChangeListener { _, b ->
             btnSignUp.isEnabled = b
         }
+
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Description

Fixed the issue in this [task](https://codein.withgoogle.com/dashboard/task-instances/5990120386199552/).

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

I ran the APP on my phone. This is the gif:

![](https://i.imgur.com/fQQWfAZ.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules