### PR TITLE
[Program:GCI] Create BaseViewModel class and make ViewModels inherit it

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/HomeFragment.kt
@@ -72,8 +72,8 @@ class HomeFragment : BaseFragment() {
                 }
             })
 
-            message.observe(viewLifecycleOwner, Observer { message ->
-                Snackbar.make(homeContainer, message.toString(), Snackbar.LENGTH_SHORT).show()
+            liveMessage.observe(viewLifecycleOwner, Observer { liveMessage ->
+                Snackbar.make(homeContainer, liveMessage.toString(), Snackbar.LENGTH_SHORT).show()
             })
         }
     }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/BaseViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/BaseViewModel.kt
@@ -1,0 +1,64 @@
+package org.systers.mentorship.viewmodels
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import io.reactivex.observers.DisposableObserver
+import org.systers.mentorship.MentorshipApplication
+import org.systers.mentorship.R
+import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.SingleLiveEvent
+import retrofit2.HttpException
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+abstract class BaseViewModel : ViewModel() {
+
+    abstract val TAG: String
+    val successful: MutableLiveData<Boolean> = MutableLiveData()
+    val _message = SingleLiveEvent<String>()
+    val liveMessage: LiveData<String>
+        get() = _message
+    lateinit var message: String
+
+    fun observer(next: (t: Any) -> Unit, error: (() -> Unit)?): DisposableObserver<Any> {
+        return object: DisposableObserver<Any>() {
+
+            override fun onError(throwable: Throwable) {
+                when (throwable) {
+                    is IOException -> {
+                        message = MentorshipApplication.getContext()
+                                .getString(R.string.error_please_check_internet)
+
+                    }
+                    is TimeoutException -> {
+                        message = MentorshipApplication.getContext()
+                                .getString(R.string.error_request_timed_out)
+                    }
+                    is HttpException -> {
+                        message = CommonUtils.getErrorResponse(throwable).message.toString()
+                    }
+                    else -> {
+                        message = MentorshipApplication.getContext()
+                                .getString(R.string.error_something_went_wrong)
+                        Log.e(TAG, throwable.localizedMessage)
+                    }
+                }
+                _message.value = message
+                Log.i("TAG", "error msg in baseviewmodel: "+ liveMessage.value)
+                successful.value = false
+                error?.let { it() }
+            }
+
+            override fun onComplete() {
+                // Do nothing
+            }
+
+            override fun onNext(nextItem: Any) {
+                next(nextItem)
+                successful.value = true
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/viewmodels/ChangePasswordViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/ChangePasswordViewModel.kt
@@ -4,26 +4,19 @@ import android.annotation.SuppressLint
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.remote.requests.ChangePassword
 import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] used for ChangePasswordFragment
  */
-class ChangePasswordViewModel : ViewModel() {
+class ChangePasswordViewModel : BaseViewModel() {
 
+    override var TAG: String = ChangePasswordViewModel::class.java.simpleName
     private val userDataManager: UserDataManager = UserDataManager()
     val successfulUpdate: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * Updates the password of the current user
@@ -33,35 +26,12 @@ class ChangePasswordViewModel : ViewModel() {
         userDataManager.updatePassword(changePassword)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successfulUpdate.value = true
-                    }
-
-                    override fun onError(e: Throwable) {
-                        when (e) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(e).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                            }
-                        }
-                        successfulUpdate.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successfulUpdate.value = true
+                        },
+                        error = {successfulUpdate.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/HomeViewModel.kt
@@ -1,79 +1,35 @@
 package org.systers.mentorship.viewmodels
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.remote.datamanager.UserDataManager
-import org.systers.mentorship.utils.CommonUtils
-import org.systers.mentorship.utils.SingleLiveEvent
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
-
 
 /**
  * This class represents the ViewModel for the HomeFragment
  */
-class HomeViewModel : ViewModel() {
+class HomeViewModel : BaseViewModel() {
 
-    private val TAG = this::class.java.simpleName
+    override val TAG: String = this::class.java.simpleName
     private val userDataManager by lazy { UserDataManager() }
     private val compositeDisposable by lazy { CompositeDisposable() }
 
     private val _userStats = MutableLiveData<HomeStatistics>()
-    private val _message = SingleLiveEvent<String>()
-
     val userStats: LiveData<HomeStatistics>
         get() = _userStats
-
-    val message: LiveData<String>
-        get() = _message
 
     init {
         userDataManager.getHomeStats()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object: DisposableObserver<HomeStatistics>() {
-
-                    override fun onComplete() {
-                        // Do nothing
-                    }
-
-                    override fun onNext(statistics: HomeStatistics) {
-                        _userStats.value = statistics
-                    }
-
-                    override fun onError(error: Throwable) {
-                        when (error) {
-                            is IOException -> {
-                                _message.postValue(MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet))
-                            }
-                            is TimeoutException -> {
-                                _message.postValue(MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out))
-                            }
-                            is HttpException -> {
-                                _message.postValue(CommonUtils.getErrorResponse(error).message)
-                            }
-                            else -> {
-                                _message.postValue(MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong))
-                                        .also { Log.d(TAG, error.localizedMessage) }
-                            }
-                        }
-                    }
-
-                })
+                .subscribeWith(observer(
+                        next = { _userStats.value = it as HomeStatistics },
+                        error = {} //no boolean in HomeViewModel
+                ))
                 .addTo(compositeDisposable)
     }
 
@@ -82,4 +38,3 @@ class HomeViewModel : ViewModel() {
         compositeDisposable.dispose()
     }
 }
-

--- a/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/LoginViewModel.kt
@@ -1,36 +1,24 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.AuthDataManager
 import org.systers.mentorship.remote.requests.Login
 import org.systers.mentorship.remote.responses.AuthToken
-import org.systers.mentorship.utils.CommonUtils
 import org.systers.mentorship.utils.PreferenceManager
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the Login Activity
  */
-class LoginViewModel : ViewModel() {
+class LoginViewModel : BaseViewModel() {
 
-    var TAG = LoginViewModel::class.java.simpleName
+    override var TAG: String = LoginViewModel::class.java.simpleName
 
     private val preferenceManager: PreferenceManager = PreferenceManager()
     private val authDataManager: AuthDataManager = AuthDataManager()
-
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * Will be used to run the login method of the AuthService
@@ -41,36 +29,12 @@ class LoginViewModel : ViewModel() {
         authDataManager.login(login)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<AuthToken>() {
-                    override fun onNext(authToken: AuthToken) {
-                        successful.value = true
-                        preferenceManager.putAuthToken(authToken.authToken)
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            preferenceManager.putAuthToken((it as AuthToken).authToken)
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MemberProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MemberProfileViewModel.kt
@@ -1,33 +1,22 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the MemberProfileActivity
  */
-class MemberProfileViewModel : ViewModel() {
+class MemberProfileViewModel : BaseViewModel() {
 
-    var TAG = MemberProfileViewModel::class.java.simpleName
+    override var TAG: String = MemberProfileViewModel::class.java.simpleName
 
     private val userDataManager: UserDataManager = UserDataManager()
 
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
     lateinit var userProfile: User
 
     /**
@@ -39,36 +28,12 @@ class MemberProfileViewModel : ViewModel() {
         userDataManager.getUser(userId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<User>() {
-                    override fun onNext(user: User) {
-                        userProfile = user
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            userProfile = it as User
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
@@ -1,32 +1,19 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the Members Activity
  */
-class MembersViewModel : ViewModel() {
+class MembersViewModel : BaseViewModel() {
 
-    var TAG = MembersViewModel::class.java.simpleName
-
+    override var TAG: String = MembersViewModel::class.java.simpleName
     private val userDataManager: UserDataManager = UserDataManager()
-
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
     lateinit var userList: List<User>
 
     /**
@@ -37,36 +24,12 @@ class MembersViewModel : ViewModel() {
         userDataManager.getUsers()
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<List<User>>() {
-                    override fun onNext(userListResponse: List<User>) {
-                        userList = userListResponse
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            userList = it as List<User>
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
@@ -3,33 +3,23 @@ package org.systers.mentorship.viewmodels
 import android.annotation.SuppressLint
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
-import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] used for ProfileFragment
  */
-class ProfileViewModel: ViewModel() {
+class ProfileViewModel: BaseViewModel() {
 
-    var TAG = ProfileViewModel::class.java.simpleName
+    override var TAG: String = ProfileViewModel::class.java.simpleName
 
     private val userDataManager: UserDataManager = UserDataManager()
 
     val successfulGet: MutableLiveData<Boolean> = MutableLiveData()
     val successfulUpdate: MutableLiveData<Boolean> = MutableLiveData()
     lateinit var user: User
-    lateinit var message: String
 
     /**
      * Fetches the current users full profile
@@ -39,35 +29,13 @@ class ProfileViewModel: ViewModel() {
         userDataManager.getUser()
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<User>() {
-                    override fun onNext(userprofile: User) {
-                        user = userprofile
-                        successfulGet.value = true
-                    }
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successfulGet.value = false
-                    }
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            user = it as User
+                            successfulGet.value = true
+                        },
+                        error = {successfulGet.value = false}
+                ))
     }
 
     /**
@@ -78,33 +46,9 @@ class ProfileViewModel: ViewModel() {
         userDataManager.updateUser(user)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(response: CustomResponse) {
-                        successfulUpdate.value = true
-                    }
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successfulUpdate.value = false
-                    }
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {successfulUpdate.value = true},
+                        error = {successfulUpdate.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/RelationViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/RelationViewModel.kt
@@ -3,33 +3,24 @@ package org.systers.mentorship.viewmodels
 import android.annotation.SuppressLint
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.remote.datamanager.RelationDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the Sign Up Activity
  */
-class RelationViewModel : ViewModel() {
+class RelationViewModel : BaseViewModel() {
 
-    var TAG = RelationViewModel::class.java.simpleName
+    override var TAG: String = RelationViewModel::class.java.simpleName
 
     private val relationDataManager: RelationDataManager = RelationDataManager()
 
     val successfulGet: MutableLiveData<Boolean> = MutableLiveData()
     val successfulCancel: MutableLiveData<Boolean> = MutableLiveData()
     lateinit var mentorshipRelation: Relationship
-    lateinit var message: String
 
     /**
      * Fetches current relation details
@@ -39,37 +30,12 @@ class RelationViewModel : ViewModel() {
         relationDataManager.getCurrentRelationship()
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<Relationship>() {
-                    override fun onNext(relationship: Relationship) {
-                        mentorshipRelation = relationship
-                        successfulGet.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successfulGet.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = { mentorshipRelation = it as Relationship
+                            successfulGet.value = true
+                        },
+                        error = {successfulGet.value = false}
+                ))
     }
 
     /**
@@ -80,36 +46,12 @@ class RelationViewModel : ViewModel() {
         relationDataManager.cancelRelationship(relationId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successfulCancel.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successfulCancel.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successfulCancel.value = true
+                        },
+                        error = {successfulCancel.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/RequestDetailViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/RequestDetailViewModel.kt
@@ -1,32 +1,20 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.RelationDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] used for Request Detail Screen
  */
-class RequestDetailViewModel : ViewModel() {
+class RequestDetailViewModel : BaseViewModel() {
 
-    var TAG = RequestDetailViewModel::class.java.simpleName
+    override var TAG: String = RequestDetailViewModel::class.java.simpleName
 
     private val relationDataManager = RelationDataManager()
-
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * Accepts a mentorship request
@@ -37,37 +25,13 @@ class RequestDetailViewModel : ViewModel() {
         relationDataManager.acceptRelationship(requestId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 
     /**
@@ -79,37 +43,13 @@ class RequestDetailViewModel : ViewModel() {
         relationDataManager.rejectRelationship(requestId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 
     /**
@@ -121,36 +61,12 @@ class RequestDetailViewModel : ViewModel() {
         relationDataManager.deleteRelationship(requestId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/RequestsViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/RequestsViewModel.kt
@@ -1,32 +1,19 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
 import org.systers.mentorship.remote.datamanager.RelationDataManager
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] used for Requests Screen
  */
-class RequestsViewModel : ViewModel() {
+class RequestsViewModel : BaseViewModel() {
 
-    var TAG = RequestsViewModel::class.java.simpleName
-
+    override var TAG: String = RequestsViewModel::class.java.simpleName
     private val relationDataManager = RelationDataManager()
-
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
     lateinit var allRequestsList: List<Relationship>
 
     /**
@@ -37,36 +24,13 @@ class RequestsViewModel : ViewModel() {
         relationDataManager.getAllRelationsAndRequests()
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<List<Relationship>>() {
-                    override fun onNext(relationsList: List<Relationship>) {
-                        allRequestsList = relationsList
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            @Suppress("UNCHECKED_CAST")
+                            allRequestsList = it as List<Relationship>
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/SendRequestViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/SendRequestViewModel.kt
@@ -1,34 +1,25 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.RelationDataManager
 import org.systers.mentorship.remote.requests.RelationshipRequest
 import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the Send Request Activity
  */
-class SendRequestViewModel : ViewModel() {
+class SendRequestViewModel : BaseViewModel() {
 
-    var TAG = SendRequestViewModel::class.java.simpleName
+    override var TAG: String = SendRequestViewModel::class.java.simpleName
 
     private val relationDataManager: RelationDataManager = RelationDataManager()
 
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * Call send a mentorship request service
@@ -39,37 +30,16 @@ class SendRequestViewModel : ViewModel() {
         relationDataManager.sendRequest(relationshipRequest)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message ?: MentorshipApplication.getContext()
-                                .getString(R.string.registration_successful)
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            if(message.isEmpty()){
                                 message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
+                                        .getString(R.string.registration_successful)
                             }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/SignUpViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/SignUpViewModel.kt
@@ -1,34 +1,21 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import android.util.Log
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.annotations.NonNull
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.remote.datamanager.AuthDataManager
 import org.systers.mentorship.remote.requests.Register
 import org.systers.mentorship.remote.responses.CustomResponse
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] component used for the Sign Up Activity
  */
-class SignUpViewModel : ViewModel() {
+class SignUpViewModel : BaseViewModel() {
 
-    var TAG = SignUpViewModel::class.java.simpleName
-
+    override var TAG: String = SignUpViewModel::class.java.simpleName
     private val authDataManager: AuthDataManager = AuthDataManager()
-
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * Will be used to run the register method of the AuthService
@@ -39,36 +26,12 @@ class SignUpViewModel : ViewModel() {
         authDataManager.register(register)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<CustomResponse>() {
-                    override fun onNext(customResponse: CustomResponse) {
-                        message = customResponse.message
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            message = (it as CustomResponse).message
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModel.kt
@@ -1,33 +1,22 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import android.util.Log
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
-import org.systers.mentorship.MentorshipApplication
-import org.systers.mentorship.R
 import org.systers.mentorship.models.Task
 import org.systers.mentorship.remote.datamanager.TaskDataManager
-import org.systers.mentorship.utils.CommonUtils
-import retrofit2.HttpException
-import java.io.IOException
-import java.util.concurrent.TimeoutException
 
 /**
  * This class represents the [ViewModel] used for Tasks Screen
  */
-class TasksViewModel: ViewModel() {
+class TasksViewModel: BaseViewModel() {
 
-    var TAG = TasksViewModel::class.java.simpleName
+    override var TAG: String = TasksViewModel::class.java.simpleName
 
     lateinit var tasksList: List<Task>
 
     private val taskDataManager: TaskDataManager = TaskDataManager()
-    val successful: MutableLiveData<Boolean> = MutableLiveData()
-    lateinit var message: String
 
     /**
      * This function lists all tasks from the mentorship relation
@@ -37,37 +26,14 @@ class TasksViewModel: ViewModel() {
         taskDataManager.getAllTasks(relationId)
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<List<Task>>() {
-                    override fun onNext(taskListResponse: List<Task>) {
-                        tasksList = taskListResponse
-                        successful.value = true
-                    }
-
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message.toString()
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(TAG, throwable.localizedMessage)
-                            }
-                        }
-                        successful.value = false
-                    }
-
-                    override fun onComplete() {
-                    }
-                })
+                .subscribeWith(observer(
+                        next = {
+                            @Suppress("UNCHECKED_CAST")
+                            tasksList = it as List<Task>
+                            successful.value = true
+                        },
+                        error = {successful.value = false}
+                ))
     }
 
     /**


### PR DESCRIPTION
### Description
BaseViewModel class created with common code for observers. It is extended to other ViewModel classes.  All common code related to onNext(), onError() and onComplete() moved to function **observer()** in BaseViewModel. It takes two arguments- **next** and **error** for all observers.

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)

### How Has This Been Tested?
Screenshots
1. Signup
![task68_1](https://user-images.githubusercontent.com/50169911/72529523-7e633400-3893-11ea-88d1-705fe4f888dc.gif)

2. Signin
![task68_2](https://user-images.githubusercontent.com/50169911/72529524-7e633400-3893-11ea-98c2-6fcec214d5bd.gif)

3. Home
![task68_3](https://user-images.githubusercontent.com/50169911/72529525-7e633400-3893-11ea-89c1-b09b2bc3b1e7.png)

4. Profile
![task68_4](https://user-images.githubusercontent.com/50169911/72529527-7efbca80-3893-11ea-9f84-e69b9ecfa380.gif)

5. Relation
![task68_5](https://user-images.githubusercontent.com/50169911/72529528-7efbca80-3893-11ea-85f6-13f462c1c301.gif)

6. Members
![task68_6](https://user-images.githubusercontent.com/50169911/72529530-7f946100-3893-11ea-85ac-5d709a0bf64c.gif)

7. Requests
![task68_7](https://user-images.githubusercontent.com/50169911/72529532-7f946100-3893-11ea-9f5c-03ee76110402.gif)

8. Errors
![task86_8](https://user-images.githubusercontent.com/50169911/72529834-13fec380-3894-11ea-8fff-0d68d3d39e52.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules