### PR TITLE
[Program: GCI] Integrated tasks with the API

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/TaskDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/TaskDataManager.kt
@@ -3,6 +3,7 @@ package org.systers.mentorship.remote.datamanager
 import io.reactivex.Observable
 import org.systers.mentorship.models.Task
 import org.systers.mentorship.remote.ApiManager
+import org.systers.mentorship.remote.requests.TaskRequest
 import org.systers.mentorship.remote.responses.CustomResponse
 
 /**
@@ -13,7 +14,7 @@ class TaskDataManager {
     private val apiManager = ApiManager.instance
 
     /**
-     * This will call a method from Taskservice interface to fetch all tasks
+     * Calls a method from Taskservice interface to fetch all tasks
      * @param relationId mentorship relation id
      * @return an Observable of [CustomResponse]
      */
@@ -21,4 +22,36 @@ class TaskDataManager {
         return apiManager.taskService.getAllTasksFromMentorshipRelation(relationId)
     }
 
+    /**
+     * Calls a method from [org.systers.mentorship.remote.services.TaskService] interface
+     * to create a new task
+     * @param relationId id of the current relation the user is involved in
+     * @param taskRequest data needed to create a request
+     * @return an Observable of [CustomResponse]
+     */
+    fun createTask(relationId: Int, taskRequest: TaskRequest): Observable<CustomResponse> {
+        return apiManager.taskService.createTask(relationId, taskRequest)
+    }
+
+    /**
+     * Calls a method from [org.systers.mentorship.remote.services.TaskService] interface
+     * to complete the task with specified id within current user's relation
+     * @param requestId mentorship request id
+     * @param taskId id of the task to mark as completed
+     * @return an Observable of [CustomResponse]
+     */
+    fun completeTask(requestId: Int, taskId: Int): Observable<CustomResponse> {
+        return apiManager.taskService.completeTask(requestId, taskId)
+    }
+
+    /**
+     * Calls a method from [org.systers.mentorship.remote.services.TaskService] interface
+     * to *delete* the task with specified id within current user's relation
+     * @param requestId mentorship request id
+     * @param taskId id of the task to be deleted
+     * @return an Observable of [CustomResponse]
+     */
+    fun deleteTask(requestId: Int, taskId: Int): Observable<CustomResponse> {
+        return apiManager.taskService.deleteTask(requestId, taskId)
+    }
 }

--- a/app/src/main/java/org/systers/mentorship/remote/requests/TaskRequest.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/TaskRequest.kt
@@ -1,0 +1,9 @@
+package org.systers.mentorship.remote.requests
+
+/**
+ * Represents all data necessary to create a task for a relation between two users
+ * @param description represents description of the task
+ */
+data class TaskRequest(
+    val description: String
+)

--- a/app/src/main/java/org/systers/mentorship/remote/services/TaskService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/TaskService.kt
@@ -2,6 +2,8 @@ package org.systers.mentorship.remote.services
 
 import io.reactivex.Observable
 import org.systers.mentorship.models.Task
+import org.systers.mentorship.remote.requests.TaskRequest
+import org.systers.mentorship.remote.responses.CustomResponse
 import retrofit2.http.*
 
 /**
@@ -10,10 +12,37 @@ import retrofit2.http.*
 interface TaskService {
 
     /**
-     * This function gets all the tasks from a mentorship relation
+     * Gets all the tasks from a mentorship relation
      * @param relationId id of the mentorship relation in question
      * @return an observable instance of a list of [Task]s
      */
     @GET("mentorship_relation/{relation_id}/tasks")
     fun getAllTasksFromMentorshipRelation(@Path("relation_id") relationId: Int): Observable<List<Task>>
+
+    /**
+     * Creates a new task all the tasks from a mentorship relation
+     * @param requestId id of the mentorship relation request between two users
+     * @param taskRequest data needed to create a request
+     * @return an Observable of [CustomResponse]
+     */
+    @POST("mentorship_relation/{request_id}/task")
+    fun createTask(@Path("request_id") requestId: Int, @Body taskRequest: TaskRequest): Observable<CustomResponse>
+
+    /**
+     * Marks the task with the specified id as done/completed.
+     * @param requestId id of the mentorship relation request between two users
+     * @param taskId id of the task to mark as completed
+     * @return an Observable of [CustomResponse]
+     */
+    @PUT("mentorship_relation/{request_id}/task/{task_id}/complete")
+    fun completeTask(@Path("request_id") requestId: Int, @Path("task_id") taskId: Int): Observable<CustomResponse>
+
+    /**
+     * Deletes the task with the specified id from a mentorship relation
+     * @param requestId id of the mentorship relation request between two users
+     * @param taskId id of the task to be deleted
+     * @return an Observable of [CustomResponse]
+     */
+    @DELETE("mentorship_relation/{request_id}/task/{task_id}")
+    fun deleteTask(@Path("request_id") requestId: Int, @Path("task_id") taskId: Int): Observable<CustomResponse>
 }

--- a/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/TasksAdapter.kt
@@ -1,44 +1,108 @@
 package org.systers.mentorship.view.adapters
 
-import androidx.recyclerview.widget.RecyclerView
+import android.app.AlertDialog
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.task_list_item.view.*
-import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Task
 
+
 /**
  * This class represents the adapter that fills in each view of the Tasks recyclerView
- * @param taskstsList list of tasks taken up by the mentee
- * @param markTask function to be called when an item from Tasks list is clicked
+ * @param context Context required by the adapter to work properly
+ * @param tasks list of tasks taken up by the mentee
+ * @param completeTask method to be called when a task on the task list is checked
+ * @param deleteTask method to be called when a task on the task list is deleted
  */
 class TasksAdapter(
-        private val tasksList: List<Task>,
-        private val markTask: (taskId: Int) -> Unit
+    private val context: Context,
+    private val completeTask: (taskId: Int) -> Unit,
+    private val deleteTask: (taskId: Int) -> Unit
 ) : RecyclerView.Adapter<TasksAdapter.TaskViewHolder>() {
 
-    val context = MentorshipApplication.getContext();
+    var tasks: List<Task> = arrayListOf()
+        set(newTasks) {
+            val diffCallback = MembersDiffCallback(tasks, newTasks)
+            val diffResult = DiffUtil.calculateDiff(diffCallback)
+
+            field = newTasks
+            diffResult.dispatchUpdatesTo(this)
+        }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TaskViewHolder =
-            TaskViewHolder(
-                    LayoutInflater.from(parent.context)
-                            .inflate(R.layout.task_list_item, parent, false))
+        TaskViewHolder(
+            LayoutInflater.from(parent.context).inflate(R.layout.task_list_item, parent, false)
+        )
 
     override fun onBindViewHolder(holder: TaskViewHolder, position: Int) {
-        val item = tasksList[position]
+        val task = tasks[position]
         val itemView = holder.itemView
+        val checkBox = itemView.cbTask
+        val deleteButton = itemView.btnDeleteTask
 
-        itemView.cbTask.text = item.description
-        itemView.setOnClickListener { markTask(position) }
+        checkBox.text = task.description
+        checkBox.isChecked = task.isDone
+        checkBox.isEnabled = !task.isDone
+
+        checkBox.setOnCheckedChangeListener { _, checked ->
+            if (!checked) {
+                return@setOnCheckedChangeListener
+            }
+
+            val thisTask = tasks[holder.adapterPosition]
+
+            AlertDialog.Builder(context).setTitle(R.string.complete_task)
+                .setMessage(context.getString(R.string.complete_task_are_you_sure, thisTask.description))
+                .setPositiveButton(R.string.complete_task) { _, _ ->
+                    itemView.cbTask.isEnabled = false
+                    completeTask(thisTask.id)
+                }
+                .setNeutralButton(R.string.cancel) { _, _ ->
+                    if (checked) {
+                        itemView.cbTask.isChecked = false
+                    }
+                }
+                .show()
+        }
+
+        deleteButton.setOnClickListener {
+            val thisTask = tasks[holder.adapterPosition]
+
+            AlertDialog.Builder(context).setTitle(R.string.delete_task)
+                .setMessage(context.getString(R.string.delete_task_are_you_sure, thisTask.description))
+                .setPositiveButton(R.string.delete) { _, _ ->
+                    deleteTask(thisTask.id)
+                }
+                .setNeutralButton(R.string.cancel) { _, _ -> }
+                .show()
+        }
     }
 
-    override fun getItemCount(): Int = tasksList.size
+    override fun getItemCount(): Int = tasks.size
 
     /**
      * This class holds a view for each item of the Tasks list
      * @param itemView represents each view of Tasks list
      */
-    class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+    inner class TaskViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+
+    inner class MembersDiffCallback(
+        private val oldList: List<Task>, private val newList: List<Task>
+    ) : DiffUtil.Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+            oldList[oldItemPosition] == newList[newItemPosition]
+
+        override fun getOldListSize() = oldList.size
+
+        override fun getNewListSize() = newList.size
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
+            oldList[oldItemPosition] == newList[newItemPosition]
+
+    }
 }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/TasksFragment.kt
@@ -1,28 +1,32 @@
 package org.systers.mentorship.view.fragments
 
+import android.animation.Animator
+import android.animation.LayoutTransition
+import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
 import android.app.AlertDialog
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import android.view.View
-import androidx.recyclerview.widget.LinearLayoutManager
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.EditText
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_mentorship_tasks.*
-import kotlinx.android.synthetic.main.task_list_item.*
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.Relationship
-import org.systers.mentorship.view.activities.MainActivity
 import org.systers.mentorship.view.adapters.TasksAdapter
+import org.systers.mentorship.viewmodels.TaskViewModelFactory
 import org.systers.mentorship.viewmodels.TasksViewModel
 
-@SuppressLint("ValidFragment")
+
 /**
  * The fragment is responsible for showing the all mentorship tasks
  * and achievements. It also allows to add new tasks.
  */
+@SuppressLint("ValidFragment")
 class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment() {
 
     companion object {
@@ -30,71 +34,188 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
          * Creates an instance of [TasksFragment]
          */
         fun newInstance(mentorshipRelation: Relationship) = TasksFragment(mentorshipRelation)
-        val TAG = TasksFragment::class.java.simpleName
+
+        private val TAG = TasksFragment::class.java.simpleName
     }
 
-    val appContext = MentorshipApplication.getContext()
+    private val appContext = MentorshipApplication.getContext()
 
     private lateinit var taskViewModel: TasksViewModel
 
-    override fun getLayoutResourceId(): Int = R.layout.fragment_mentorship_tasks;
+    override fun getLayoutResourceId(): Int = R.layout.fragment_mentorship_tasks
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        taskViewModel = ViewModelProviders.of(this).get(TasksViewModel::class.java)
-        taskViewModel.successful.observe(this, Observer {
-            successful ->
-            if (successful != null) {
-                if (successful) {
-                    if (taskViewModel.tasksList.isEmpty()) {
-                        tvNoTask.visibility = View.VISIBLE
-                        rvTasks.visibility = View.GONE
-                    } else {
-                        rvTasks.apply {
-                            layoutManager = LinearLayoutManager(context)
-                            adapter = TasksAdapter(taskViewModel.tasksList, markTask)
-                        }
-                        tvNoTask.visibility = View.GONE
-                    }
+        val tasksAdapter = TasksAdapter(baseActivity, markTask, deleteTask)
+        val achievementsAdapter = TasksAdapter(baseActivity, markTask, deleteTask)
+
+        rvTasks.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = tasksAdapter
+        }
+
+        rvAchievements.apply {
+            layoutManager = LinearLayoutManager(context)
+            adapter = achievementsAdapter
+        }
+
+        taskViewModel = ViewModelProviders.of(this, TaskViewModelFactory(mentorshipRelation))
+            .get(TasksViewModel::class.java)
+
+        taskViewModel.getSuccessful.observe(this, Observer { successful ->
+            if (successful == true) {
+                if (taskViewModel.tasks.isEmpty()) {
+                    tvNoTask.visibility = VISIBLE
+                    tvNoAchievements.visibility = VISIBLE
+                    rvTasks.visibility = GONE
+                    rvAchievements.visibility = GONE
                 } else {
-                    view?.let {
-                        Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
-                    }
+                    tvNoTask.visibility = GONE
+                    tvNoAchievements.visibility = GONE
+                    rvTasks.visibility = VISIBLE
+                    rvAchievements.visibility = VISIBLE
+
+                    tasksAdapter.tasks = taskViewModel.tasks.filter { !it.isDone }
+                    achievementsAdapter.tasks = taskViewModel.tasks.filter { it.isDone }
+                }
+            } else {
+                view?.let {
+                    Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
                 }
             }
         })
+
+        taskViewModel.createSuccessful.observe(this, Observer { successful ->
+            if (successful == true) {
+                view?.let {
+                    Snackbar.make(it, R.string.task_added, Snackbar.LENGTH_LONG).show()
+                }
+            } else {
+                view?.let {
+                    Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
+                }
+            }
+        })
+
+        taskViewModel.completeSuccessful.observe(this, Observer { successful ->
+            if (successful == true) {
+                view?.let {
+                    Snackbar.make(it, R.string.task_completed, Snackbar.LENGTH_LONG).show()
+                }
+            } else {
+                view?.let {
+                    Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
+                }
+            }
+        })
+
+        taskViewModel.deleteSuccessful.observe(this, Observer { successful ->
+            if (successful == true) {
+                view?.let {
+                    Snackbar.make(it, R.string.task_deleted, Snackbar.LENGTH_LONG).show()
+                }
+            } else {
+                view?.let {
+                    Snackbar.make(it, taskViewModel.message, Snackbar.LENGTH_LONG).show()
+                }
+            }
+        })
+
+        taskViewModel.getTasks()
 
         fabAddItem.setOnClickListener {
             showDialog()
         }
 
-        taskViewModel.getTasks(mentorshipRelation.id)
+        // Enables animations when child view's property changes
+        clRootTasks.layoutTransition = LayoutTransition().apply {
+            enableTransitionType(LayoutTransition.CHANGING)
+        }
 
+        btnExpandTasks.setOnClickListener {
+            with(rvTasks) {
+                visibility = if (visibility == VISIBLE) GONE else VISIBLE
+            }
+
+            val currentRotation = btnExpandTasks.rotation
+
+            ObjectAnimator.ofFloat(
+                btnExpandTasks, "rotation", currentRotation, currentRotation + 180
+            ).apply {
+                addListener(object : Animator.AnimatorListener {
+                    override fun onAnimationStart(animator: Animator?) {
+                        btnExpandTasks.isClickable = false
+                    }
+
+                    override fun onAnimationEnd(animator: Animator?) {
+                        btnExpandTasks.isClickable = true
+                    }
+
+                    override fun onAnimationRepeat(animator: Animator?) {}
+
+                    override fun onAnimationCancel(animator: Animator?) {}
+                })
+                duration = 300
+                start()
+            }
+        }
+
+        btnExpandAchievements.setOnClickListener {
+            with(rvAchievements) {
+                visibility = if (visibility == VISIBLE) GONE else VISIBLE
+            }
+
+            val currentRotation = btnExpandAchievements.rotation
+
+            ObjectAnimator.ofFloat(
+                btnExpandAchievements, "rotation", currentRotation, currentRotation + 180
+            ).apply {
+                addListener(object : Animator.AnimatorListener {
+                    override fun onAnimationStart(animator: Animator?) {
+                        btnExpandAchievements.isClickable = false
+                    }
+
+                    override fun onAnimationEnd(animator: Animator?) {
+                        btnExpandAchievements.isClickable = true
+                    }
+
+
+                    override fun onAnimationRepeat(animator: Animator?) {}
+
+                    override fun onAnimationCancel(animator: Animator?) {}
+                })
+                duration = 300
+                start()
+            }
+        }
     }
 
     /**
-     * The function creates a dialog box through whoch new tasks can be added
+     * Creates a dialog box through which new tasks can be added
      */
-    fun showDialog() {
+    private fun showDialog() {
         val builder = AlertDialog.Builder(context)
         val inflater = layoutInflater
         builder.setTitle(appContext.getString(R.string.add_new_task))
-        val dialogLayout = inflater.inflate(R.layout.dialog_add_task, null)
+        val dialogLayout = inflater.inflate(R.layout.dialog_add_task, null, false)
         val editText = dialogLayout.findViewById<EditText>(R.id.etAddTask)
         builder.setView(dialogLayout)
-        builder.setPositiveButton(appContext.getString(R.string.save)) { dialogInterface, i ->
+        builder.setPositiveButton(appContext.getString(R.string.save)) { _, _ ->
             val newTask: String = editText.text.toString()
-            taskViewModel.addTask(newTask)
+            taskViewModel.createTask(newTask)
         }
-        builder.setNegativeButton(appContext.getString(R.string.cancel)) { dialogInterface, i ->
+        builder.setNegativeButton(appContext.getString(R.string.cancel)) { dialogInterface, _ ->
             dialogInterface.dismiss()
         }
         builder.show()
     }
 
     private val markTask: (Int) -> Unit = { taskId ->
-        cbTask.isChecked
-        taskViewModel.updateTask(taskId, cbTask.isChecked)
+        taskViewModel.completeTask(taskId)
+    }
+
+    private val deleteTask: (Int) -> Unit = { taskId ->
+        taskViewModel.deleteTask(taskId)
     }
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModelFactory.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/TaskViewModelFactory.kt
@@ -1,0 +1,14 @@
+package org.systers.mentorship.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import org.systers.mentorship.models.Relationship
+
+class TaskViewModelFactory(private val mentorshipRelation: Relationship) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        return TasksViewModel(mentorshipRelation) as T
+    }
+
+}

--- a/app/src/main/res/layout/fragment_mentorship_tasks.xml
+++ b/app/src/main/res/layout/fragment_mentorship_tasks.xml
@@ -4,7 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:id="@+id/clRootTasks"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvTodo"
@@ -21,17 +23,18 @@
         android:id="@+id/rvTasks"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tvTodo"
-        app:layout_constraintVertical_weight="0.5"
-        android:layout_marginLeft="16dp" />
+        app:layout_constraintVertical_weight="0.5" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvNoTask"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="12dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginTop="16dp"
         android:text="No tasks"
         android:textAlignment="center"
         app:layout_constraintTop_toBottomOf="@id/tvTodo"
@@ -52,7 +55,7 @@
         android:id="@+id/rvAchievements"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="16dp"
         android:layout_marginEnd="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -60,12 +63,12 @@
         app:layout_constraintVertical_weight="0.5" />
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/imageView"
+        android:id="@+id/btnExpandTasks"
         android:layout_width="30dp"
         android:layout_height="30dp"
-        android:layout_marginEnd="16dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="@+id/tvTodo"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toEndOf="@+id/tvTodo"
@@ -73,28 +76,26 @@
         app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp" />
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/imageView2"
+        android:id="@+id/btnExpandAchievements"
         android:layout_width="30dp"
         android:layout_height="30dp"
-        android:layout_marginEnd="16dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="@+id/tvAchievements"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toEndOf="@+id/tvAchievements"
         app:layout_constraintTop_toTopOf="@+id/tvAchievements"
-        app:srcCompat="@drawable/ic_keyboard_arrow_down_black_24dp" />
+        app:srcCompat="@drawable/ic_keyboard_arrow_up_black_24dp" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/tvNoAchievements"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="12dp"
-        android:layout_marginBottom="12dp"
+        android:layout_marginTop="16dp"
         android:text="No achievements"
         android:textAlignment="center"
-        app:layout_constraintTop_toBottomOf="@id/rvAchievements"
+        app:layout_constraintTop_toBottomOf="@+id/tvAchievements"
         app:layout_constraintVertical_weight="0.5" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/task_list_item.xml
+++ b/app/src/main/res/layout/task_list_item.xml
@@ -10,8 +10,19 @@
         android:id="@+id/cbTask"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:text="CheckBox"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="CheckBox" />
+
+    <ImageButton
+        android:id="@+id/btnDeleteTask"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/icon_trash_task_delete_description"
+        app:backgroundTint="@android:color/transparent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_delete_black_24dp" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,12 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="task_completed">Congratulations! Task completed successfully!</string>
+    <string name="task_added">Task added successfully!</string>
+    <string name="task_deleted">Task deleted successfully!</string>
+    <string name="icon_trash_task_delete_description">Icon of a trash can. Touch to delete a task.</string>
+    <string name="complete_task">Complete task</string>
+    <string name="delete_task">Delete task</string>
+    <string name="complete_task_are_you_sure">"Are you sure that you want to complete \"%1$s\"? This action cannot be undone.</string>
+    <string name="delete_task_are_you_sure">Are you sure that you want to delete \"%1$s\"? This action cannot be undone.</string>
 </resources>


### PR DESCRIPTION
### Description
I implemented what was required by [this task](https://codein.withgoogle.com/dashboard/task-instances/5558046357454848/) – that is, full integration of the tasks feature with the [backend API](http://systers-mentorship-dev.eu-central-1.elasticbeanstalk.com/).

- added task-related methods  in TaskService and TaskDataManager
- added possibility to create a new task by tapping on a FAB
- added possibility to mark the task as completed by checking a CheckBox
- added possibility to delete the task by tapping on a trash icon
- Enabled expanding/collapsing of the task lists with a nice animation
- Task addition and deletion operations also have a nice accompanying animation thanks to the use of [`DiffUtils`](https://developer.android.com/reference/android/support/v7/util/DiffUtil).

### Type of Change:
- Code
- User Interface
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)

### How Has This Been Tested?
Tested manually on the emulator. Everything works fine, gifs below:

![demo](https://user-images.githubusercontent.com/40357511/72615275-9e96ff80-3934-11ea-9da8-668a2ff18932.gif)

**Also, 3 most recent tasks are displayed in `HomeFragment`**
<img width="305" alt="Screenshot 2020-01-17 at 2 25 58 PM" src="https://user-images.githubusercontent.com/40357511/72615634-79ef5780-3935-11ea-9231-a0e591f7ac78.png">


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my code or materials
- [x] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have written Kotlin Docs whenever is applicable

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes