### PR TITLE
[Program: GCI] Add ViewPager in MainActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,6 @@ dependencies {
 
     implementation Dependencies.lifecycle_extensions
     implementation Dependencies.lifecycle_viewmodel
+
+    implementation Dependencies.viewpager2
 }

--- a/app/src/main/java/org/systers/mentorship/utils/Constants.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Constants.kt
@@ -9,4 +9,6 @@ object Constants {
     const val RELATIONSHIP_EXTRA = "relationship_extra"
     const val DELETE_REQUEST_RESULT_ID = 1000
     const val REQUEST_ID = "request_id"
+    const val NUM_PAGES = 5
+
 }

--- a/app/src/main/java/org/systers/mentorship/utils/DepthPageTransformer.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/DepthPageTransformer.kt
@@ -1,0 +1,50 @@
+package org.systers.mentorship.utils
+
+import android.view.View
+import androidx.annotation.RequiresApi
+import androidx.viewpager2.widget.ViewPager2
+
+private const val MIN_SCALE = 0.75f
+
+@RequiresApi(21)
+class DepthPageTransformer : ViewPager2.PageTransformer {
+
+    override fun transformPage(view: View, position: Float) {
+        view.apply {
+            val pageWidth = width
+            when {
+                position < -1 -> { // [-Infinity,-1)
+                    // This page is way off-screen to the left.
+                    alpha = 0f
+                }
+                position <= 0 -> { // [-1,0]
+                    // Use the default slide transition when moving to the left page
+                    alpha = 1f
+                    translationX = 0f
+                    translationZ = 0f
+                    scaleX = 1f
+                    scaleY = 1f
+                }
+                position <= 1 -> { // (0,1]
+                    // Fade the page out.
+                    alpha = 1 - position
+
+                    // Counteract the default slide transition
+                    translationX = pageWidth * -position
+                    // Move it behind the left page
+                    translationZ = -1f
+
+                    // Scale the page down (between MIN_SCALE and 1)
+                    val scaleFactor = (MIN_SCALE + (1 - MIN_SCALE) * (1 - Math.abs(position)))
+                    scaleX = scaleFactor
+                    scaleY = scaleFactor
+                }
+                else -> { // (1,+Infinity]
+                    // This page is way off-screen to the right.
+                    alpha = 0f
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -1,28 +1,54 @@
 package org.systers.mentorship.view.activities
 
+import android.annotation.TargetApi
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
-import android.os.PersistableBundle
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import android.view.Menu
 import android.view.MenuItem
+import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.android.synthetic.main.activity_main.*
 import org.systers.mentorship.R
-import org.systers.mentorship.utils.PreferenceManager
+import org.systers.mentorship.utils.Constants.NUM_PAGES
+import org.systers.mentorship.utils.DepthPageTransformer
 import org.systers.mentorship.view.fragments.*
 
 /**
  * This activity has the bottom navigation which allows the user to switch between fragments
  */
-class MainActivity: BaseActivity() {
+class MainActivity : BaseActivity() {
 
     private var atHome = true
 
-    private val preferenceManager: PreferenceManager = PreferenceManager()
-
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        viewPagerMain.adapter = ScreenSlidePagerAdapter(this)
+        viewPagerMain.setPageTransformer(DepthPageTransformer())
+        // for BottomNavigationBar to represent the new fragment
+        viewPagerMain.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                bottomNavigation.selectedItemId =
+                        when (position) {
+                            0 -> R.id.navigation_home
+                            1 -> R.id.navigation_profile
+                            2 -> R.id.navigation_relation
+                            3 -> R.id.navigation_members
+                            4 -> R.id.navigation_requests
+                            else -> R.id.navigation_home
+                        }
+                atHome = position == 0
+            }
+        })
+        // in order to allow to use ViewPager inside of a ViewPager
+        viewPagerMain.reduceDragSensitivity()
 
         bottomNavigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
 
@@ -35,40 +61,35 @@ class MainActivity: BaseActivity() {
 
     private val mOnNavigationItemSelectedListener =
             BottomNavigationView.OnNavigationItemSelectedListener { item ->
-        when (item.itemId) {
-            R.id.navigation_home -> {
-                replaceFragment(R.id.contentFrame, HomeFragment.newInstance(),
-                        R.string.fragment_title_home)
-                atHome = true
-                return@OnNavigationItemSelectedListener true
+                when (item.itemId) {
+                    R.id.navigation_home -> {
+                        viewPagerMain.currentItem = 0
+                        atHome = true
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_profile -> {
+                        viewPagerMain.currentItem = 1
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_relation -> {
+                        viewPagerMain.currentItem = 2
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_members -> {
+                        viewPagerMain.currentItem = 3
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                    R.id.navigation_requests -> {
+                        viewPagerMain.currentItem = 4
+                        atHome = false
+                        return@OnNavigationItemSelectedListener true
+                    }
+                }
+                false
             }
-            R.id.navigation_profile -> {
-                replaceFragment(R.id.contentFrame, ProfileFragment.newInstance(),
-                        R.string.fragment_title_profile)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_relation -> {
-                replaceFragment(R.id.contentFrame, RelationPagerFragment.newInstance(),
-                        R.string.fragment_title_relation)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_members -> {
-                replaceFragment(R.id.contentFrame, MembersFragment.newInstance(),
-                        R.string.fragment_title_members)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-            R.id.navigation_requests -> {
-                replaceFragment(R.id.contentFrame, RequestsFragment.newInstance(),
-                        R.string.fragment_title_requests)
-                atHome = false
-                return@OnNavigationItemSelectedListener true
-            }
-        }
-        false
-    }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.main_menu, menu)
@@ -87,7 +108,7 @@ class MainActivity: BaseActivity() {
     private fun showHomeFragment() {
         atHome = true
         bottomNavigation.selectedItemId = R.id.navigation_home
-        replaceFragment(R.id.contentFrame, HomeFragment.newInstance(), R.string.fragment_title_home)
+        viewPagerMain.currentItem = 0
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -103,4 +124,32 @@ class MainActivity: BaseActivity() {
             super.onBackPressed()
         }
     }
+
+    private fun ViewPager2.reduceDragSensitivity() {
+        val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
+        recyclerViewField.isAccessible = true
+        val recyclerView = recyclerViewField.get(this) as RecyclerView
+
+        val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
+        touchSlopField.isAccessible = true
+        val touchSlop = touchSlopField.get(recyclerView) as Int
+        touchSlopField.set(recyclerView, (touchSlop*1.6).toInt())       // "1.6" was obtained experimentally
+    }
+
+    /**
+     * A simple pager adapter that represents 5 main fragments
+     */
+    private inner class ScreenSlidePagerAdapter(fa: FragmentActivity) : FragmentStateAdapter(fa) {
+        override fun getItemCount(): Int = NUM_PAGES
+        override fun createFragment(position: Int) =
+                when (position) {
+                    0 -> HomeFragment.newInstance()
+                    1 -> ProfileFragment.newInstance()
+                    2 -> RelationPagerFragment.newInstance()
+                    3 -> MembersFragment.newInstance()
+                    4 -> RequestsFragment.newInstance()
+                    else -> HomeFragment.newInstance()
+                }
+    }
+
 }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -55,7 +55,7 @@ class EditProfileFragment: DialogFragment() {
                 }
             }
         })
-        dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        dialog?.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         isCancelable = false
         return inflater.inflate(R.layout.fragment_edit_profile, container, false)
     }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -63,7 +63,7 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
+                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager!!,
                         getString(R.string.fragment_title_edit_profile))
                 true
             }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,26 +7,19 @@
     android:layout_height="match_parent"
     tools:context=".view.activities.MainActivity">
 
-    <FrameLayout
-        android:id="@+id/contentFrame"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPagerMain"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/bottomNavigation"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1.0" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNavigation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:labelVisibilityMode="labeled"
-        android:layout_marginEnd="0dp"
-        android:layout_marginStart="0dp"
         android:background="?android:attr/windowBackground"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     const val testRule = "1.1.0"
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
-
+    const val viewpager2 = "1.0.0"
 }
 
 /**
@@ -53,4 +53,5 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+    const val viewpager2 = "androidx.viewpager2:viewpager2:${Versions.viewpager2}"
 }


### PR DESCRIPTION
### Description
- Added ViewPager2 in the MainActivity in order to allow swipe between main fragments
- I used DepthPageTransformer animation, which could be found in [the official documentation](https://developer.android.com/jetpack/androidx/releases/viewpager2)
- I also needed to reduce scroll sensitivity of the ViewPager in order to allow the use of the other ViewPagers we have in Relation and Requests fragments [link](https://medium.com/@al.e.shevelev/how-to-reduce-scroll-sensitivity-of-viewpager2-widget-87797ad02414) (P.S. it was a bit hard to find)
- I also needed to change 2 lines of code in Profile and EditProfileFragment because of the failing build. I guess it happens because of the new library.

This PR also requires a database or at least caching function, so that it doesn't look buggy and laggy because of the AlertDialogs for loading data.

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my smartphone.

### Gif:
![20200119_165943](https://user-images.githubusercontent.com/34242059/72684196-c2964480-3ade-11ea-94fd-c054301c2f8a.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules