### PR TITLE
[Program:GCI] Precision loss while storing end date timestamp

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/RelationFragment.kt
@@ -76,6 +76,10 @@ class RelationFragment(private var mentorshipRelation: Relationship) : BaseFragm
         activityCast.hideProgressDialog()
             tvMentorName.text = relationResponse.mentor.name
             tvMenteeName.text = relationResponse.mentee.name
+            println("creation date is "+relationResponse.sentOn)
+            println("creation date is (in long) "+relationResponse.sentOn.toLong())
+            println("end date is "+relationResponse.endsOn)
+            println("end date is (in long) "+relationResponse.endsOn.toLong())
             tvEndDate.text = convertUnixTimestampIntoStr(
                     relationResponse.endsOn, EXTENDED_DATE_FORMAT)
             tvRelationNotes.text = relationResponse.notes


### PR DESCRIPTION
### Description
The Relationship class reads relationship data from the backend and converts the end date to float format. However this leads to loss of precision. The mentorship relation will then expire some time before or after the displayed date. This also creates problems for sorting or filtering mentorship requests. [In a previous task](https://github.com/systers/mentorship-android/pull/469/files) I had to write code to prevent user from sending similar requests with similar ending time. The timestamps was not directly comparable and had to be converted to another format. This with seen in **creation_date**, **end_date** and other dates stored. To fix this Double or a special date class should be used for storing dates.

For example the sever returns ```1585679404``` as end_date but this is getting rounded off to ```1.58567936E9 =1585679360```

This PR is in reference to #540

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Logcat
![task76_1](https://user-images.githubusercontent.com/50169911/72787044-1aef5280-3c55-11ea-9514-d8ab87c87c6c.png)

2. Swagger
![task76_2](https://user-images.githubusercontent.com/50169911/72786313-512bd280-3c53-11ea-97fe-9fd9371259cc.png)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules