### PR TITLE
Added notice about open-source software used

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,8 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'kotlin-kapt'
 
+apply plugin: 'com.google.android.gms.oss-licenses-plugin'
+
 android {
     compileSdkVersion Versions.compileSdkVersion
     defaultConfig {
@@ -48,6 +50,7 @@ dependencies {
     implementation Dependencies.design
     implementation Dependencies.constraint_layout
     implementation Dependencies.appCompat
+    implementation Dependencies.oss_licenses
     kapt Dependencies.databinding
     testImplementation Dependencies.junit
     androidTestImplementation Dependencies.test_runner

--- a/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/AboutActivity.kt
@@ -5,6 +5,7 @@ import android.content.res.Resources
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import kotlinx.android.synthetic.main.activity_about.*
 import org.systers.mentorship.R
 
@@ -36,6 +37,9 @@ class AboutActivity : AppCompatActivity() {
         }
         btncodeofconduct.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_code_of_conduct))))
+        }
+        btnosslicenses.setOnClickListener {
+            startActivity(Intent(this, OssLicensesMenuActivity::class.java))
         }
 
     }

--- a/app/src/main/res/drawable/ic_code_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_code_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M9.4,16.6L4.8,12l4.6,-4.6L8,6l-6,6 6,6 1.4,-1.4zM14.6,16.6l4.6,-4.6 -4.6,-4.6L16,6l6,6 -6,6 -1.4,-1.4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -280,6 +280,44 @@
 
                 </androidx.cardview.widget.CardView>
 
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/btnosslicenses"
+                    android:layout_width="130dp"
+                    android:layout_height="100dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:layout_margin="20dp"
+                    android:outlineAmbientShadowColor="#55111109"
+                    android:outlineSpotShadowColor="#55111109"
+                    app:cardBackgroundColor="@color/aubergine"
+                    app:cardCornerRadius="20dp">
+
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical">
+
+                        <ImageView
+                            android:layout_width="114dp"
+                            android:layout_height="0dp"
+                            app:srcCompat="@drawable/ic_code_white_24dp"
+                            android:layout_gravity="center"
+                            android:layout_weight="3" />
+
+                        <androidx.appcompat.widget.AppCompatTextView
+                            android:layout_width="match_parent"
+                            android:layout_height="38dp"
+                            android:layout_gravity="center"
+                            android:gravity="center"
+                            android:text="@string/oss_licenses"
+                            android:textColor="#fff"
+                            android:textSize="14sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                </androidx.cardview.widget.CardView>
+
 
             </GridLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,5 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="url_terms">https://anitab.org/terms-of-use/</string>
     <string name="url_privacy">https://anitab.org/privacy-policy/</string>
     <string name="url_code_of_conduct">https://ghc.anitab.org/code-of-conduct/</string>
+    <string name="oss_licenses">Open Source licenses</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ buildscript {
         classpath Dependencies.gradle_build_tool
         classpath Dependencies.kotlin_gradle_plugin
 
+        classpath Dependencies.oss_licenses_plugin
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -25,7 +25,8 @@ object Versions {
     const val testRule = "1.1.0"
     const val supportAnnotation = "1.0.0"
     const val appCompat = "1.0.0-beta01"
-
+    const val ossLicenses = "17.0.0"
+    const val ossLicensesPlugin = "0.10.1"
 }
 
 /**
@@ -53,4 +54,6 @@ object Dependencies {
     const val lifecycle_extensions = "androidx.lifecycle:lifecycle-extensions:${Versions.archComponents}"
     const val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.archComponents}"
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
+    const val oss_licenses = "com.google.android.gms:play-services-oss-licenses:${Versions.ossLicenses}"
+    const val oss_licenses_plugin = "com.google.android.gms:oss-licenses-plugin:${Versions.ossLicensesPlugin}"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 24 16:33:21 IST 2018
+#Sun Jan 26 18:37:27 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
### Description
I have added the [Google Open Source Licenses plugin](https://developers.google.com/android/guides/opensource) which makes it easy to comply with the license requirements of open source libraries.

In `AboutActivity`, an additional button has been added. When the user taps it, the Activity displaying a list of all open-source software is being displayed. Users can tap on the list item to access the library's license.

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
This is a simple functionality, so I tested this manually. Demo gif below:
![demo](https://user-images.githubusercontent.com/40357511/73139182-add02880-406b-11ea-8545-61a6075a5583.gif)g


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules