### PR TITLE
fix: changes the status bar color to theme color

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,8 +6,8 @@
     <color name="rich_black">#EF4135</color>
     <color name="white">#FFFFFF</color>
     <color name="black">#000000</color>
-    <color name="aubergine">#8D2165</color>
-    <color name="navy">#005c88</color>
+    <color name="aubergine">#751A55</color>
+    <color name="navy">#66164A</color>
     <color name="caribbean">#54BCEB</color>
     <color name="scarlet">#EF4135</color>
 </resources>


### PR DESCRIPTION
After merging the PR it fixes the issue #570. 
Changes the status bar color according to the theme color.

Before PR merge
![Screenshot_2020-02-21-20-40-32-674_org systers mentorship 1](https://user-images.githubusercontent.com/39822483/75054062-5604d000-54f8-11ea-8996-7d3574b4b677.png)

Fix: Status bar synchronized

![Screenshot_2020-02-21-22-19-22-383_org systers mentorship 1](https://user-images.githubusercontent.com/39822483/75054143-8482ab00-54f8-11ea-94b4-644bc52aa671.png)




Fixes #570

### Type of Change:

- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.


### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged



**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes