### PR TITLE
fix:Password change button after confirm

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -1,14 +1,16 @@
 package org.systers.mentorship.view.fragments
 
 import android.app.Dialog
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.DialogFragment
-import androidx.appcompat.app.AlertDialog
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
 import kotlinx.android.synthetic.main.fragment_change_password.view.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.ChangePassword
@@ -54,7 +56,31 @@ class ChangePasswordFragment : DialogFragment() {
         builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
             dialog.cancel()
         }
-        return builder.create()
+
+        val passwordDialog = builder.create()
+
+        passwordDialog.setOnShowListener {
+            passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
+
+            changePasswordView.tilConfirmPassword?.editText?.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(p0: Editable?) {
+                    if (p0!!.isEmpty())
+                        passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
+                }
+
+                override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                    passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
+                }
+
+                override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                    passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = p0 != ""
+                }
+
+            })
+
+        }
+
+        return passwordDialog
     }
 
     override fun onResume() {
@@ -76,7 +102,7 @@ class ChangePasswordFragment : DialogFragment() {
         }
     }
 
-    private fun validatePassword() : Boolean {
+    private fun validatePassword(): Boolean {
         return if (newPassword == confirmPassword && newPassword != currentPassword) {
             true
         } else {

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -58,22 +58,21 @@ class ChangePasswordFragment : DialogFragment() {
         }
 
         val passwordDialog = builder.create()
-
         passwordDialog.setOnShowListener {
             passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
 
             changePasswordView.tilConfirmPassword?.editText?.addTextChangedListener(object : TextWatcher {
-                override fun afterTextChanged(p0: Editable?) {
-                    if (p0!!.isEmpty())
+                override fun afterTextChanged(confirmPasswordEditable: Editable?) {
+                    if (confirmPasswordEditable!!.isEmpty())
                         passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
                 }
 
-                override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                override fun beforeTextChanged(confirmPasswordText: CharSequence?, p1: Int, p2: Int, p3: Int) {
                     passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false
                 }
 
-                override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                    passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = p0 != ""
+                override fun onTextChanged(confirmPasswordText: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                    passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = confirmPasswordText != ""
                 }
 
             })


### PR DESCRIPTION
### Description
fix:Password change button after confirm.

Fixes #573 

### Type of Change:

<img src="https://user-images.githubusercontent.com/43133646/75131430-19ec8d80-56f9-11ea-84cb-f81beb84646b.gif" width=300 />


- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules