### PR TITLE
fix: Members Search does not work

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -80,10 +80,12 @@ class MembersFragment : BaseFragment() {
                 userList.add(user)
             }
         }
+        rvAdapter = MembersAdapter(userList, ::openUserProfile)
         rvMembers.apply {
             layoutManager = LinearLayoutManager(context)
-            adapter = MembersAdapter(userList, ::openUserProfile)
+            adapter = rvAdapter
         }
+        rvAdapter.filter(filterMap)
         tvEmptyList.visibility = View.GONE
     }
     override fun onActivityCreated(savedInstanceState: Bundle?) {


### PR DESCRIPTION
### Description
`MembersAdapter` has a `userList` and a `filteredUserList`. The `filteredUserList` is what is shown to the user.

When a search term is entered, an object of `MembersAdapter` class is created. But, whenever `MembersAdapter` is created, only the `userList` is set in the object, and `filteredUserList` is empty (`filteredUserList = mutableListOf<User>()`). So, only an empty list is used to show the members to the user, thus the search feature wouldn't work.

### Approach I chose

If we take a look at what happens after the members list is fetched from the backend, we see the following:
```
// ... members list fetched from backend
rvAdapter.setData(membersViewModel.userList)
rvAdapter.filter(filterMap)
```
Note that after setting the data (modifying the `userList` member of the class), a call to the `MembersAdapter.filter()` function is made, which sets the `filteredUserList` member based on the existing filters. Thus, we need to make a call to `MembersAdapter.filter()` so that `filteredUserList` gets set.

### Other Approaches

When a `MembersAdapter` is created or it's `setData` function is called, we can also call filter method, since we expect the `filteredUserList` to be set to a list corresponding to the new data, instead of remaining unchanged.

I didn't use this approach since this also involves refactoring of calls to `setData`/creation of object `MembersAdapter` in other places.

Fixes #594 

### Type of Change:

- Code
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Ran it on my emulator.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings