### PR TITLE
fix: change backend URL to temporary one

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/BaseUrl.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/BaseUrl.kt
@@ -21,7 +21,9 @@ object BaseUrl {
 
     val apiBaseUrl: String
         get() = if (BuildConfig.BUILD_TYPE == "debug"){
-            "$PROTOCOL_HTTPS$DEVELOPMENT_URL$EB_REGION"
+            // "$PROTOCOL_HTTPS$DEVELOPMENT_URL$EB_REGION"
+            // TODO: once backend is fixed remove this temporary URL
+            "https://mentorship-backend-temp.herokuapp.com/"
         } else if (BuildConfig.BUILD_TYPE == "debug_localhost"){
             "$PROTOCOL_HTTPS$LOCALHOST_URL$LOCALHOST_PORT"
         } else {


### PR DESCRIPTION
### Description

I changed the backend URL to a temporary working one, until the AWS deployed server issue is solved. Until then, we can use this server and allow for contributors to test the Android application without having to worry with setting up the backend locally (for any type of contributor, whether they are android developers or just Application breakers that want to test the Android apk only)

Fixes #635

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I did not, I have to say. I really hope Travis build does not fail me (: 

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules