### PR TITLE
Fix systers references generate-apks script

### DIFF
--- a/generate-apks.sh
+++ b/generate-apks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Travis build triggered on a forked repository
-if [ "$TRAVIS_REPO_SLUG" != "systers/mentorship-android" ]; then
+if [ "$TRAVIS_REPO_SLUG" != "anitab-org/mentorship-android" ]; then
     echo "Not the original repo. Skip apk upload."
     exit 0
 fi
@@ -36,8 +36,8 @@ if [ "$TRAVIS_BRANCH" == "develop" ]; then
     git init
 
     # Copy the generated apks in to the repository we just created
-    cp $HOME/build/systers/mentorship-android/app/build/outputs/apk/debug/app-debug.apk $HOME/apk/
-    cp $HOME/build/systers/mentorship-android/app/build/outputs/apk/release/app-release-unsigned.apk $HOME/apk/
+    cp $HOME/build/anitab-org/mentorship-android/app/build/outputs/apk/debug/app-debug.apk $HOME/apk/
+    cp $HOME/build/anitab-org/mentorship-android/app/build/outputs/apk/release/app-release-unsigned.apk $HOME/apk/
 
     # Add and commit the apks
     git add app-debug.apk
@@ -47,8 +47,8 @@ if [ "$TRAVIS_BRANCH" == "develop" ]; then
     # Rename the current branch from master to apk
     git branch -m apk
 
-    # Pushing the apk branch to the systers repository
-    git push https://m-murad:$GITHUB_API_KEY@github.com/systers/mentorship-android apk -fq> /dev/null
+    # Pushing the apk branch to the anitab-org repository
+    git push https://m-murad:$GITHUB_API_KEY@github.com/anitab-org/mentorship-android apk -fq> /dev/null
     if [ $? -eq 0 ]; then
         echo "Apk push successful."
     else


### PR DESCRIPTION
### Description

Fix Systers organization references on `generate-apks.sh` script. This is probably the reason why no apks have been generated recently.

Fixes #639

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I did not yet 🤷‍♀ but it does make sense to change this


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules