### PR TITLE
Fix: Last item of recyclerview hiding behind bottom nav bar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,8 @@
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
         android:fitsSystemWindows="true">
 
 


### PR DESCRIPTION
### Description
Fixed the last item hiding behind the bottom nav bar

Fixes #631

### Before
![before](https://user-images.githubusercontent.com/52661249/76941681-7589ef80-6922-11ea-9d47-9f5f379f706b.png)


### After
![WhatsApp Image 2020-03-18 at 2 10 57 PM](https://user-images.githubusercontent.com/52661249/76941704-80dd1b00-6922-11ea-914d-5ff202bcdf83.jpeg)



### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on OnePlus6t




**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
