### PR TITLE
Back Button fixed in Edit Profile Page

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -57,7 +57,7 @@ class EditProfileFragment: DialogFragment() {
             }
         })
         dialog.window!!.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        isCancelable = false
+        isCancelable = true
         return inflater.inflate(R.layout.fragment_edit_profile, container, false)
     }
 


### PR DESCRIPTION
### Description
In Edit Profile Page, Back Button has been fixed. Now, both CANCEL Button and Back Button can be used, if the user does not want to save the changes made in Edit Profile Page.

Fixes #661 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
![Hi](https://user-images.githubusercontent.com/54908756/77803473-35093f00-70a3-11ea-80a2-efafec87090d.gif)



### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes