### PR TITLE
fix : signUp with mentee/mentor unchecked

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
@@ -19,4 +19,5 @@ data class Register (
         val password: String,
         val termsAndConditionsChecked: Boolean,
         val needMentoring: Boolean,
-        val availableToMentor: Boolean)
+        val availableToMentor: Boolean,
+        val isAvailableForBoth: Boolean)

--- a/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/Register.kt
@@ -19,5 +19,4 @@ data class Register (
         val password: String,
         val termsAndConditionsChecked: Boolean,
         val needMentoring: Boolean,
-        val availableToMentor: Boolean,
-        val isAvailableForBoth: Boolean)
+        val availableToMentor: Boolean)

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -3,6 +3,7 @@ package org.systers.mentorship.view.activities
 import android.content.Intent
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
+import android.view.View
 import android.widget.Toast
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -112,6 +113,14 @@ class SignUpActivity : BaseActivity() {
             isValid = false
         } else {
             tiConfirmPassword.error = null
+        }
+        if (!needsMentoring && !isAvailableToMentor) {
+            isValid = false
+            cbMentee.requestFocus()
+            cbMentor.requestFocus()
+            tvNoteSignUp.visibility = View.VISIBLE
+        } else {
+            tvNoteSignUp.visibility = View.GONE
         }
 
         return isValid

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -29,7 +29,7 @@ class SignUpActivity : BaseActivity() {
     private lateinit var confirmedPassword: String
     private var isAvailableToMentor: Boolean = false
     private var needsMentoring: Boolean = false
-    private var isAvailableForBoth = false
+    private var isAvailableForBoth: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,7 +61,7 @@ class SignUpActivity : BaseActivity() {
             isAvailableForBoth = cbBoth.isChecked
 
             if (validateDetails()) {
-                val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor, isAvailableForBoth)
+                val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor)
                 signUpViewModel.register(requestData)
                 showProgressDialog(getString(R.string.signing_up))
             }
@@ -122,6 +122,10 @@ class SignUpActivity : BaseActivity() {
             cbMentor.requestFocus()
             cbBoth.requestFocus()
             tvNoteSignUp.visibility = View.VISIBLE
+        } else if (isAvailableForBoth) {
+            needsMentoring = true
+            isAvailableToMentor = true
+            tvNoteSignUp.visibility = View.GONE
         } else {
             tvNoteSignUp.visibility = View.GONE
         }

--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -29,6 +29,7 @@ class SignUpActivity : BaseActivity() {
     private lateinit var confirmedPassword: String
     private var isAvailableToMentor: Boolean = false
     private var needsMentoring: Boolean = false
+    private var isAvailableForBoth = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -57,9 +58,10 @@ class SignUpActivity : BaseActivity() {
             confirmedPassword = tiConfirmPassword.editText?.text.toString()
             needsMentoring = cbMentee.isChecked //old name but works
             isAvailableToMentor = cbMentor.isChecked //old name but works
+            isAvailableForBoth = cbBoth.isChecked
 
             if (validateDetails()) {
-                val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor)
+                val requestData = Register(name, username, email, password, true, needsMentoring, isAvailableToMentor, isAvailableForBoth)
                 signUpViewModel.register(requestData)
                 showProgressDialog(getString(R.string.signing_up))
             }
@@ -114,10 +116,11 @@ class SignUpActivity : BaseActivity() {
         } else {
             tiConfirmPassword.error = null
         }
-        if (!needsMentoring && !isAvailableToMentor) {
+        if (!needsMentoring && !isAvailableToMentor && !isAvailableForBoth) {
             isValid = false
             cbMentee.requestFocus()
             cbMentor.requestFocus()
+            cbBoth.requestFocus()
             tvNoteSignUp.visibility = View.VISIBLE
         } else {
             tvNoteSignUp.visibility = View.GONE

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -119,16 +119,36 @@
             app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
             app:layout_constraintTop_toBottomOf="@+id/tiConfirmPassword" />
 
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tvNoteSignUp"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginEnd="8dp"
+            android:gravity="center"
+            android:maxLines="2"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:text="@string/error_checkbox"
+            android:textColor="@color/scarlet"
+            android:textSize="14sp"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
+
         <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cbMentor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:text="@string/mentor"
+            android:focusable="true"
             app:layout_constraintEnd_toStartOf="@+id/cbMentee"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
-            app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
+            app:layout_constraintTop_toBottomOf="@+id/tvNoteSignUp" />
 
         <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cbMentee"
@@ -137,10 +157,12 @@
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:text="@string/mentee"
+            android:focusable="true"
             app:layout_constraintEnd_toEndOf="@+id/tiConfirmPassword"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toEndOf="@+id/cbMentor"
-            app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
+            app:layout_constraintTop_toBottomOf="@+id/tvNoteSignUp" />
+
 
         <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cbTC"
@@ -148,19 +170,19 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
-            app:layout_constraintTop_toBottomOf="@+id/cbMentee" />
+            app:layout_constraintTop_toBottomOf="@+id/cbMentor" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tvTC"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="16dp"
             android:text="@string/terms_and_conditions_acceptance_statement"
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="@id/tiConfirmPassword"
             app:layout_constraintStart_toEndOf="@id/cbTC"
-            app:layout_constraintTop_toBottomOf="@id/cbMentee" />
+            app:layout_constraintTop_toBottomOf="@id/cbMentor" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnSignUp"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -138,39 +138,50 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/appCompatTextView" />
 
-        <androidx.appcompat.widget.AppCompatCheckBox
-            android:id="@+id/cbMentor"
-            android:layout_width="wrap_content"
+        <RadioGroup
+            android:id="@+id/radio_group"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="@string/mentor"
-            android:focusable="true"
-            app:layout_constraintEnd_toStartOf="@+id/cbMentee"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
-            app:layout_constraintTop_toBottomOf="@+id/tvNoteSignUp" />
+            android:gravity="center_horizontal"
+            android:orientation="horizontal"
+            app:layout_constraintEnd_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvNoteSignUp">
 
-        <androidx.appcompat.widget.AppCompatCheckBox
-            android:id="@+id/cbMentee"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:text="@string/mentee"
-            android:focusable="true"
-            app:layout_constraintEnd_toEndOf="@+id/tiConfirmPassword"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/cbMentor"
-            app:layout_constraintTop_toBottomOf="@+id/tvNoteSignUp" />
+            <RadioButton
+                android:id="@+id/cbMentor"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:focusable="true"
+                android:text="@string/mentor" />
 
+            <RadioButton
+                android:id="@+id/cbMentee"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:focusable="true"
+                android:text="@string/mentee" />
 
+            <RadioButton
+                android:id="@+id/cbBoth"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:focusable="true"
+                android:text="@string/both" />
+        </RadioGroup>
         <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cbTC"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             app:layout_constraintStart_toStartOf="@+id/tiConfirmPassword"
-            app:layout_constraintTop_toBottomOf="@+id/cbMentor" />
+            app:layout_constraintTop_toBottomOf="@+id/radio_group" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tvTC"
@@ -182,7 +193,7 @@
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="@id/tiConfirmPassword"
             app:layout_constraintStart_toEndOf="@id/cbTC"
-            app:layout_constraintTop_toBottomOf="@id/cbMentor" />
+            app:layout_constraintTop_toBottomOf="@id/radio_group" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btnSignUp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,5 +189,6 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="same_request_already_sent">You have already sent a similar request to\u0020</string>
     <string name="relationpage_btntext">Find members</string>
     <string name="refresh">Refresh</string>
+    <string name="error_checkbox">Please choose at least one of the following options.\n You may change it later</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,5 +190,6 @@ We engage our community by contributing to open source, collaborating with the g
     <string name="relationpage_btntext">Find members</string>
     <string name="refresh">Refresh</string>
     <string name="error_checkbox">Please choose at least one of the following options.\n You may change it later</string>
+    <string name="both">Both</string>
 </resources>
 


### PR DESCRIPTION
### Description
Earlier, the user was able to sign up successfully even if he did not choose to be either a mentor or a mentee. Now, if neither of the check boxes are clicked, the user will see a warning, and not able to sign up successfully until he selects to be at least one (Mentor/Mentee)

Fixes #676 

### Type of Change:
- [x] Code

**Code/Quality Assurance Only**
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on Oppo F11 (V09) 
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/54931749/78155725-73b04800-745b-11ea-8ad6-64d815ad9865.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x]  I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings