### PR TITLE
Fix: Ambiguous subscript of empty username/email fixed

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="error_something_went_wrong">Something went wrong</string>
     <string name="error_empty_password">Password cannot be empty</string>
     <string name="error_empty_password_confirmation">Password confirmation cannot be empty</string>
-    <string name="error_empty_username">Username cannot be empty</string>
+    <string name="error_empty_username">Username/Email cannot be empty</string>
     <string name="error_empty_email">Email cannot be empty</string>
     <string name="error_empty_name">Name cannot be empty</string>
     <string name="navigation_title_home">Home</string>


### PR DESCRIPTION
### Description
Fixes the wrong subscript of error when empty username/email is called
Fixes #677 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
![WhatsApp Image 2020-04-06 at 17 39 08](https://user-images.githubusercontent.com/54931749/78586487-249e5480-7859-11ea-8fbf-89f96e0e709e.jpeg)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
