### PR TITLE
Re: Updated profile does not show if the fragment is not refreshed

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -2,6 +2,7 @@ package org.systers.mentorship.view.fragments
 
 
 import android.app.Dialog
+import android.content.DialogInterface
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
@@ -40,7 +41,7 @@ class EditProfileFragment: DialogFragment() {
         ViewModelProviders.of(this).get(ProfileViewModel::class.java)
     }
     private lateinit var editProfileBinding: FragmentEditProfileBinding
-
+    private lateinit var onDismissListener:DialogInterface.OnDismissListener
     private lateinit var currentUser: User
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -130,5 +131,16 @@ class EditProfileFragment: DialogFragment() {
             errors += EditProfileFragmentErrorStates.NameTooLongError
         }
         return errors
+    }
+    fun setOnDismissListener(onDismissListener: DialogInterface.OnDismissListener?) {
+        this.onDismissListener = onDismissListener!!
+    }
+
+    override fun onDismiss(dialog: DialogInterface?) {
+        super.onDismiss(dialog)
+        if (onDismissListener!=null)
+        {
+            onDismissListener.onDismiss(dialog)
+        }
     }
 }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -1,5 +1,6 @@
 package org.systers.mentorship.view.fragments
 
+import android.content.DialogInterface
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
@@ -66,7 +67,12 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                EditProfileFragment.newInstance(profileViewModel.user).show(fragmentManager,
+                var editProfileFragment:EditProfileFragment = EditProfileFragment.newInstance(profileViewModel.user)
+                editProfileFragment.setOnDismissListener(DialogInterface.OnDismissListener {
+                    fetchNewest()
+                })
+
+               editProfileFragment.show(fragmentManager,
                         getString(R.string.fragment_title_edit_profile))
                 true
             }


### PR DESCRIPTION
### Description
User can see the updated profile on click of the save button.

Fixes #691

### Type of Change:
**Delete irrelevant options.**

- Code





### How Has This Been Tested?
Tested on OnePlus6t
