### PR TITLE
fix :Save in (Profile) when no change detected

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -3,17 +3,17 @@ package org.systers.mentorship.view.fragments
 
 import android.app.Dialog
 import android.content.DialogInterface
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.DialogFragment
-import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
 import org.systers.mentorship.R
 import org.systers.mentorship.databinding.FragmentEditProfileBinding
 import org.systers.mentorship.models.User
@@ -24,10 +24,11 @@ import org.systers.mentorship.viewmodels.ProfileViewModel
 /**
  * The fragment is responsible for editing the User's profile
  */
-class EditProfileFragment: DialogFragment() {
+class EditProfileFragment : DialogFragment() {
 
     companion object {
         private lateinit var tempUser: User
+
         /**
          * Creates an instance of EditProfileFragment
          */
@@ -41,8 +42,9 @@ class EditProfileFragment: DialogFragment() {
         ViewModelProviders.of(this).get(ProfileViewModel::class.java)
     }
     private lateinit var editProfileBinding: FragmentEditProfileBinding
-    private lateinit var onDismissListener:DialogInterface.OnDismissListener
+    private lateinit var onDismissListener: DialogInterface.OnDismissListener
     private lateinit var currentUser: User
+    lateinit var builder: AlertDialog
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         profileViewModel.successfulUpdate.observe(this, Observer { successful ->
@@ -74,9 +76,11 @@ class EditProfileFragment: DialogFragment() {
         dialogBuilder.setTitle(R.string.fragment_title_edit_profile)
         dialogBuilder.setPositiveButton(getString(R.string.save), null)
         dialogBuilder.setNegativeButton(getString(R.string.cancel)) { _, _ -> }
+        builder = dialogBuilder.create()
 
-        return dialogBuilder.create()
+        return builder
     }
+
 
     override fun onResume() {
         super.onResume()
@@ -106,9 +110,13 @@ class EditProfileFragment: DialogFragment() {
             }
             if (currentUser != editProfileBinding.user && errors.isEmpty()) {
                 profileViewModel.updateProfile(editProfileBinding.user!!)
+            } else if (currentUser == editProfileBinding.user && errors.isEmpty()) {
+                builder.dismiss()
             }
+
         }
     }
+
 
     override fun onDestroy() {
         super.onDestroy()
@@ -132,14 +140,14 @@ class EditProfileFragment: DialogFragment() {
         }
         return errors
     }
+
     fun setOnDismissListener(onDismissListener: DialogInterface.OnDismissListener?) {
         this.onDismissListener = onDismissListener!!
     }
 
     override fun onDismiss(dialog: DialogInterface?) {
         super.onDismiss(dialog)
-        if (onDismissListener!=null)
-        {
+        if (onDismissListener != null) {
             onDismissListener.onDismiss(dialog)
         }
     }


### PR DESCRIPTION
### Description
Fix the "Save" of the Edit Profile, to redirect to the Profile of the user, when no change is detected.

Fixes #680 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested in OPPO F11[V09]
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/54931749/80914709-026df880-8d6b-11ea-84dd-ad15c15b0576.gif)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

