### PR TITLE
fix: Hidden last items of the Profile Fragment

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -16,9 +16,10 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:paddingBottom="56dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -259,7 +260,8 @@
                         android:enabled="false"
                         android:text="@={user.interests}" />
                 </com.google.android.material.textfield.TextInputLayout>
+
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>


### PR DESCRIPTION
### Description
The last items of the Profile Fragment made visible using Nested Scroll Views and bottom padding

Fixes  #641

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on OPPO F11 [V09]
**Before**
![before](https://user-images.githubusercontent.com/54931749/80941779-f46ab700-8e00-11ea-9a79-506b7f829cb5.gif)
**After*
![after](https://user-images.githubusercontent.com/54931749/80941810-02203c80-8e01-11ea-968d-11d0277aaced.gif)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules