### PR TITLE
fix: redundant display of errors during signUp

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -83,8 +83,16 @@ class SignUpActivity : BaseActivity() {
 
     private fun validateDetails(): Boolean {
         var isValid = true
+
+        var nameTemp = name.replace("\\s".toRegex(), "")
         if (name.isBlank()) {
             tiName.error = getString(R.string.error_empty_name)
+            isValid = false
+        } else if (nameTemp.length < 2 || nameTemp.length > 31) {
+            tiName.error = getString(R.string.error_name_length)
+            isValid = false
+        } else if (!validateName(name)) {
+            tiName.error = getString(R.string.error_invalid_name)
             isValid = false
         } else {
             tiName.error = null
@@ -93,16 +101,27 @@ class SignUpActivity : BaseActivity() {
         if (username.isBlank()) {
             tiUsername.error = getString(R.string.error_empty_username)
             isValid = false
+        } else if (username.length < 4 || username.length > 26) {
+            tiUsername.error = getString(R.string.error_username_length)
+            isValid = false
+        } else if (!validateUsername(username)) {
+            tiUsername.error = getString(R.string.error_invalid_username)
+            isValid = false
         } else {
             tiUsername.error = null
         }
 
+
         if (email.isBlank()) {
             tiEmail.error = getString(R.string.error_empty_email)
+            isValid = false
+        } else if (!validateEmail(email)) {
+            tiEmail.error = getString(R.string.error_invalid_email)
             isValid = false
         } else {
             tiEmail.error = null
         }
+
 
         if (password.isBlank()) {
             tiPassword.error = getString(R.string.error_empty_password)
@@ -113,6 +132,7 @@ class SignUpActivity : BaseActivity() {
         } else {
             tiPassword.error = null
         }
+
 
         if (password != confirmedPassword) {
             tiConfirmPassword.error = getString(R.string.error_not_matching_passwords)
@@ -135,6 +155,31 @@ class SignUpActivity : BaseActivity() {
         }
 
         return isValid
+    }
+
+    private fun validateName(string: String): Boolean {
+        //Check if the name has only alphabets and not special characters or numbers
+        for (c in string) {
+            if (c !in 'A'..'Z' && c !in 'a'..'z' && c != ' ') {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun validateUsername(string: String): Boolean {
+        //Check the validity of the username
+        for (c in string) {
+            if (c !in 'A'..'Z' && c !in 'a'..'z' && c !in '0'..'9') {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun validateEmail(email: String): Boolean {
+        val EMAIL_REGEX = "^[A-Za-z](.*)([@])(.{1,})(\\.)(.{1,})"
+        return EMAIL_REGEX.toRegex().matches(email)
     }
 
     private fun navigateToLoginActivity() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,11 @@
     <string name="error_empty_username">Username/Email cannot be empty</string>
     <string name="error_empty_email">Email cannot be empty</string>
     <string name="error_empty_name">Name cannot be empty</string>
+    <string name="error_name_length">The name has to be longer than 1 character and shorter than 31 characters</string>
+    <string name="error_username_length">The username has to be longer than 1 character and shorter than 26 characters</string>
+    <string name="error_invalid_name">Your name is invalid</string>
+    <string name="error_invalid_username">Username is invalid</string>
+    <string name="error_invalid_email">Email is invalid</string>
     <string name="navigation_title_home">Home</string>
     <string name="navigation_title_profile">Profile</string>
     <string name="navigation_title_relation">Relation</string>


### PR DESCRIPTION

### Description
As a user of mentorship app, while signUp, if I the details entered by me, do not sufficiently meet the guidelines, I should be informed simultaneously
 
Fixes #668

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Tested as follows:
* ![WhatsApp Image 2020-05-04 at 15 38 26 (4)](https://user-images.githubusercontent.com/54931749/80956589-2428b780-8e1f-11ea-98a6-9546f3a3778e.jpeg)

* ![WhatsApp Image 2020-05-04 at 15 38 26 (2)](https://user-images.githubusercontent.com/54931749/80956596-25f27b00-8e1f-11ea-91a9-9cd651e39e6a.jpeg)

*![WhatsApp Image 2020-05-04 at 15 38 26 (1)](https://user-images.githubusercontent.com/54931749/80956597-268b1180-8e1f-11ea-9241-90e16a6a030b.jpeg)

* ![WhatsApp Image 2020-05-04 at 15 38 26](https://user-images.githubusercontent.com/54931749/80956599-2723a800-8e1f-11ea-945c-393ae325766a.jpeg)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
