### PR TITLE
FIX: App crashes when anything is typed in the search bar in Members Fragment

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -46,6 +46,8 @@ class MembersFragment : BaseFragment() {
         fun newInstance() = MembersFragment()
     }
 
+    private var memberListInitialized = false
+
     private val membersViewModel by lazy {
         ViewModelProviders.of(this).get(MembersViewModel::class.java)
     }
@@ -62,7 +64,8 @@ class MembersFragment : BaseFragment() {
             searchView.queryHint="Search members"
             searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextChange(newText: String): Boolean {
-                    searchUsers(newText)
+                    if(memberListInitialized)
+                        searchUsers(newText)
                     return false
                 }
                 override fun onQueryTextSubmit(query: String): Boolean {
@@ -114,6 +117,7 @@ class MembersFragment : BaseFragment() {
                             addItemDecoration(dividerItemDecoration)
                             adapter = rvAdapter
                         }
+                        memberListInitialized = true
                         tvEmptyList.visibility = View.GONE
                     }
                 } else {


### PR DESCRIPTION
### Description     
The app crashed if we typed anything into the search bar in the members fragment. The issue is now fixed.

Fixes #660 

### Type of Change:   
- Code
Added a boolean variable to check if the Member List is initialized. The searchUser function will not be called until the memberList is not initialized.


**Checklist:**
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [x]  New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules