### PR TITLE
FIX: App crashed on clicking edit profile button before the user data was loaded.

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ProfileFragment.kt
@@ -67,13 +67,13 @@ class ProfileFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_edit_profile -> {
-                var editProfileFragment:EditProfileFragment = EditProfileFragment.newInstance(profileViewModel.user)
-                editProfileFragment.setOnDismissListener(DialogInterface.OnDismissListener {
-                    fetchNewest()
-                })
-
-               editProfileFragment.show(fragmentManager,
-                        getString(R.string.fragment_title_edit_profile))
+                if(fragmentProfileBinding.user != null){
+                    var editProfileFragment:EditProfileFragment = EditProfileFragment.newInstance(profileViewModel.user)
+                    editProfileFragment.setOnDismissListener(DialogInterface.OnDismissListener {
+                        fetchNewest()
+                    })
+                    editProfileFragment.show(fragmentManager, getString(R.string.fragment_title_edit_profile))
+                }
                 true
             }
             R.id.menu_refresh -> {


### PR DESCRIPTION
The app crashed if we clicked the edit profile button while the profile data is still being fetched. The issue is now fixed.

Fixes #702 

### Description
Just added an 'if condition' which makes sure that the edit profile button does not trigger any action until the profile data has not been fetched.

### Type of Change
- Code

## Before    

![before](https://user-images.githubusercontent.com/56474716/81509578-3deb6280-9329-11ea-8ca4-397bb8db7fad.gif)

## After    

![after](https://user-images.githubusercontent.com/56474716/81509589-4e034200-9329-11ea-8f9c-001a2b7a23bb.gif)


Fixes #702 

**Checklist:**
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [x]  New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules