### PR TITLE
Fix: #679 Required error not visible in Confirm password field

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -117,9 +117,13 @@ class SignUpActivity : BaseActivity() {
         if (password != confirmedPassword) {
             tiConfirmPassword.error = getString(R.string.error_not_matching_passwords)
             isValid = false
+        } else if (confirmedPassword.isBlank()) {
+            tiConfirmPassword.error = getString(R.string.error_empty_password_confirmation)
+            isValid = false
         } else {
             tiConfirmPassword.error = null
         }
+
         if (!needsMentoring && !isAvailableToMentor && !isAvailableForBoth) {
             isValid = false
             cbMentee.requestFocus()


### PR DESCRIPTION
### Description
Fixed the bug where required error for confirm password field was not visible. Now the error is visible when confirm password field is left blank. 

Fixes #679 

### Type of Change:
- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

![Screenshot_2020-05-11-17-41-32-41_184af3f6adcdf091d91f35c3acb0ce61](https://user-images.githubusercontent.com/34762451/81561645-1f30ae80-93b1-11ea-98a8-096d544d8b4e.png)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works