### PR TITLE
pagination added to members screen

### DIFF
--- a/app/src/main/java/org/systers/mentorship/remote/datamanager/UserDataManager.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/datamanager/UserDataManager.kt
@@ -5,6 +5,7 @@ import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.ApiManager
 import org.systers.mentorship.remote.requests.ChangePassword
+import org.systers.mentorship.remote.requests.PaginationRequest
 import org.systers.mentorship.remote.responses.CustomResponse
 
 /**
@@ -21,6 +22,16 @@ class UserDataManager {
     fun getUsers(): Observable<List<User>> {
         return apiManager.userService.getVerifiedUsers()
     }
+
+
+    /**
+     * This will call the getVerifiedUsers(pagination) method of UserService interface
+     * @return an Observable of a list of [User]
+     */
+    fun getUsers(paginationRequest: PaginationRequest): Observable<List<User>> {
+        return apiManager.userService.getVerifiedUsers(paginationRequest.pagination)
+    }
+
 
     /**
      * This will call the getUser method of UserService interface

--- a/app/src/main/java/org/systers/mentorship/remote/requests/PaginationRequest.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/requests/PaginationRequest.kt
@@ -1,0 +1,11 @@
+package org.systers.mentorship.remote.requests
+
+/**
+ * This data class represents all data necessary to paginate data
+ * @param page the current page to be accessed
+ * @param perPage data limit size for per page
+ */
+data class PaginationRequest (val page: Int, val perPage: Int){
+    val pagination = mapOf("page" to page.toString(), "per_page" to perPage.toString())
+}
+

--- a/app/src/main/java/org/systers/mentorship/remote/services/UserService.kt
+++ b/app/src/main/java/org/systers/mentorship/remote/services/UserService.kt
@@ -4,6 +4,7 @@ import io.reactivex.Observable
 import org.systers.mentorship.models.HomeStatistics
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.requests.ChangePassword
+import org.systers.mentorship.remote.requests.PaginationRequest
 import org.systers.mentorship.remote.responses.CustomResponse
 import retrofit2.http.*
 
@@ -20,11 +21,21 @@ interface UserService {
     fun getUsers(): Observable<List<User>>
 
     /**
+     * This function returns all users, with email verified,
+     * of the system with requested pagination info
+     * @return an observable instance of a list of [User]s
+     */
+    @GET("users/verified")
+    fun getVerifiedUsers(@QueryMap pagination:Map<String, String>): Observable<List<User>>
+
+
+    /**
      * This function returns all users, with email verified, of the system
      * @return an observable instance of a list of [User]s
      */
     @GET("users/verified")
     fun getVerifiedUsers(): Observable<List<User>>
+
 
     /**
      * This function returns a user's public profile of the system

--- a/app/src/main/java/org/systers/mentorship/utils/Constants.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/Constants.kt
@@ -2,6 +2,7 @@ package org.systers.mentorship.utils
 
 object Constants {
 
+    const val ITEMS_PER_PAGE = 20
     const val TOTAL_REQUEST_TABS = 3
     const val MEMBER_USER_ID = "member_user_id"
     const val REQUEST_LIST = "request_list"

--- a/app/src/main/java/org/systers/mentorship/utils/EndlessRecyclerScrollListener.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/EndlessRecyclerScrollListener.kt
@@ -79,6 +79,11 @@ abstract class EndlessRecyclerScrollListener : RecyclerView.OnScrollListener {
             loading = false
             previousTotalItemCount = totalItemCount
         }
+        // If user started swipe refresh recyclerview reached the end then this exceptions is
+        // followed by this method and resets the loadMore functionality
+        if (loading && currentPage <=1){
+            loading = false
+        }
 
         // If it isn’t currently loading, we check to see if we have breached
         // the visibleThreshold and need to reload more data.

--- a/app/src/main/java/org/systers/mentorship/utils/EndlessRecyclerScrollListener.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/EndlessRecyclerScrollListener.kt
@@ -1,0 +1,96 @@
+package org.systers.mentorship.utils
+
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+
+abstract class EndlessRecyclerScrollListener : RecyclerView.OnScrollListener {
+    // The minimum amount of items to have below your current scroll position
+    // before loading more.
+    private var visibleThreshold = 5
+
+    // The current offset index of data you have loaded
+    private var currentPage = 0
+
+    // The total number of items in the data_set after the last load
+    private var previousTotalItemCount = 0
+
+    // True if we are still waiting for the last set of data to load.
+    private var loading = true
+    private var mLayoutManager: RecyclerView.LayoutManager
+
+    constructor(layoutManager: LinearLayoutManager) {
+        mLayoutManager = layoutManager
+    }
+
+    constructor(layoutManager: GridLayoutManager) {
+        mLayoutManager = layoutManager
+        visibleThreshold *= layoutManager.spanCount
+    }
+
+    constructor(layoutManager: StaggeredGridLayoutManager) {
+        mLayoutManager = layoutManager
+        visibleThreshold *= layoutManager.spanCount
+    }
+
+    private fun getLastVisibleItem(lastVisibleItemPositions: IntArray): Int {
+        var maxSize = 0
+        for (i in lastVisibleItemPositions.indices) {
+            if (i == 0) {
+                maxSize = lastVisibleItemPositions[i]
+            } else if (lastVisibleItemPositions[i] > maxSize) {
+                maxSize = lastVisibleItemPositions[i]
+            }
+        }
+        return maxSize
+    }
+
+    // This happens many times a second during a scroll, so be wary of the code you place here.
+    // We are given a few useful parameters to help us work out if we need to load some more data,
+    // but first we check if we are waiting for the previous load to finish.
+    override fun onScrolled(view: RecyclerView, dx: Int, dy: Int) {
+        var lastVisibleItemPosition = 0
+        val totalItemCount = mLayoutManager.itemCount
+        if (mLayoutManager is StaggeredGridLayoutManager) {
+            val lastVisibleItemPositions = (mLayoutManager as StaggeredGridLayoutManager).findLastVisibleItemPositions(null)
+            // get maximum element within the list
+            lastVisibleItemPosition = getLastVisibleItem(lastVisibleItemPositions)
+        } else if (mLayoutManager is LinearLayoutManager) {
+            lastVisibleItemPosition = (mLayoutManager as LinearLayoutManager).findLastVisibleItemPosition()
+        } else if (mLayoutManager is GridLayoutManager) {
+            lastVisibleItemPosition = (mLayoutManager as GridLayoutManager).findLastVisibleItemPosition()
+        }
+
+        // If the total item count is zero and the previous isn't, assume the
+        // list is invalidated and should be reset back to initial state
+        if (totalItemCount < previousTotalItemCount) {
+            // Sets the starting page index
+            currentPage = 0
+            previousTotalItemCount = totalItemCount
+            if (totalItemCount == 0) {
+                loading = true
+            }
+        }
+        // If it’s still loading, we check to see if the dataset count has
+        // changed, if so we conclude it has finished loading and update the current page
+        // number and total item count.
+        if (loading && totalItemCount > previousTotalItemCount) {
+            loading = false
+            previousTotalItemCount = totalItemCount
+        }
+
+        // If it isn’t currently loading, we check to see if we have breached
+        // the visibleThreshold and need to reload more data.
+        // If we do need to reload some more data, we execute onLoadMore to fetch the data.
+        // threshold should reflect how many total columns there are too
+        if (!loading && lastVisibleItemPosition + visibleThreshold > totalItemCount) {
+            currentPage++
+            onLoadMore(currentPage, totalItemCount)
+            loading = true
+        }
+    }
+
+    // Defines the process for actually loading more data based on page
+    abstract fun onLoadMore(page: Int, totalItemsCount: Int)
+}

--- a/app/src/main/java/org/systers/mentorship/utils/UsersDiffCallback.kt
+++ b/app/src/main/java/org/systers/mentorship/utils/UsersDiffCallback.kt
@@ -1,0 +1,24 @@
+package org.systers.mentorship.utils
+
+import androidx.recyclerview.widget.DiffUtil
+import org.systers.mentorship.models.User
+
+class UsersDiffCallback(private val mOldUsersList: List<User>, private val mNewUsersList: List<User>) : DiffUtil.Callback() {
+
+    override fun getOldListSize(): Int {
+        return mOldUsersList.size
+    }
+
+    override fun getNewListSize(): Int {
+        return mNewUsersList.size
+    }
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return mOldUsersList[oldItemPosition].id == mNewUsersList[newItemPosition].id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return mOldUsersList[oldItemPosition] == mNewUsersList[newItemPosition]
+    }
+
+}

--- a/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
@@ -7,10 +7,9 @@ import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.NonNull
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.list_member_item.view.*
-import kotlinx.android.synthetic.main.list_member_item.view.tvInterests
-import kotlinx.android.synthetic.main.list_member_item.view.tvName
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
@@ -28,14 +27,14 @@ import org.systers.mentorship.view.fragments.MembersFragment
  * @param openDetailFunction function to be called when an item from Members list is clicked
  */
 class MembersAdapter (
-        private var userList: List<User>,
+        private var userList: ArrayList<User> = arrayListOf<User>(),
         private val openDetailFunction: (memberId: Int, sharedImageView: ImageView, sharedTextView: TextView) -> Unit
 
 ) : RecyclerView.Adapter<MembersAdapter.MembersViewHolder>() {
 
     val context = MentorshipApplication.getContext()
-
     var lastPosition = -1
+    private var filterMap = hashMapOf(Constants.SORT_KEY to MembersFragment.SortValues.REGISTRATION_DATE.name)
     private var filteredUserList = mutableListOf<User>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MembersViewHolder =
@@ -68,30 +67,51 @@ class MembersAdapter (
 
     override fun getItemCount(): Int = filteredUserList.size
 
-    fun filter(map: HashMap<String, String>) {
+    fun updateUsersList(map: HashMap<String, String> ,newUsers: List<User>) {
+        //updating users list
+        setData(newUsers)
+        //getting updated filtered users
+        val newFilteredUsers = getFilteredUsers(map,newUsers)
+
+        //applying changes to adapter
+        val oldSize = filteredUserList.size
+        val newSize = newUsers.size
+        filteredUserList.clear()
+        filteredUserList.addAll(newFilteredUsers)
+
+        if (filterMap != map){
+            notifyDataSetChanged()
+            filterMap = map
+        } else notifyItemRangeChanged(oldSize,newSize)
+    }
+
+
+
+    private fun getFilteredUsers(map: HashMap<String, String>,newUsers: List<User>): List<User> {
+        var newFilteredList: List<User> = arrayListOf()
         when (map[Constants.SORT_KEY]) {
             MembersFragment.SortValues.REGISTRATION_DATE.name -> {
-                filteredUserList = userList as MutableList
+                newFilteredList = newUsers
             }
             MembersFragment.SortValues.NAMEAZ.name -> {
-                filteredUserList = userList.sortedBy {
+                newFilteredList = newUsers.sortedBy {
                     it.name
                 } as MutableList
             }
             MembersFragment.SortValues.NAMEZA.name -> {
-                filteredUserList = userList.sortedByDescending {
+                newFilteredList = newUsers.sortedByDescending {
                     it.name
                 } as MutableList
             }
         }
 
         if (map[Constants.NEED_MENTORING_KEY] == "true")
-            filteredUserList = filteredUserList.filter {
+            newFilteredList = newFilteredList.filter {
                 it.needMentoring == true
             } as MutableList<User>
 
         if (map[Constants.AVAILABLE_TO_MENTOR_KEY] == "true")
-            filteredUserList = filteredUserList.filter {
+            newFilteredList = newFilteredList.filter {
                 it.availableToMentor == true
             } as MutableList<User>
 
@@ -99,7 +119,7 @@ class MembersAdapter (
         val location = map[LOCATION_KEY]
         val skills = map[SKILLS_KEY]
 
-        filteredUserList = filteredUserList.filter {
+        newFilteredList = newFilteredList.filter {
             var valid = true
 
             if (!interests.isNullOrEmpty())
@@ -123,11 +143,13 @@ class MembersAdapter (
             valid
         } as MutableList<User>
 
-        notifyDataSetChanged()
+        return newFilteredList
     }
 
-    fun setData(users: List<User>) {
-        userList = users
+
+    private fun setData(users: List<User>) {
+        userList.clear()
+        userList.addAll(users)
     }
 
     /**

--- a/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
+++ b/app/src/main/java/org/systers/mentorship/view/adapters/MembersAdapter.kt
@@ -18,6 +18,7 @@ import org.systers.mentorship.utils.Constants.INTERESTS_KEY
 import org.systers.mentorship.utils.Constants.LOCATION_KEY
 import org.systers.mentorship.utils.Constants.SKILLS_KEY
 import org.systers.mentorship.utils.NON_VALID_VALUE_REPLACEMENT
+import org.systers.mentorship.utils.UsersDiffCallback
 import org.systers.mentorship.view.fragments.MembersFragment
 
 
@@ -74,15 +75,12 @@ class MembersAdapter (
         val newFilteredUsers = getFilteredUsers(map,newUsers)
 
         //applying changes to adapter
-        val oldSize = filteredUserList.size
-        val newSize = newUsers.size
+        val usersDiffCallback = UsersDiffCallback(filteredUserList, newFilteredUsers)
+        val diffResult = DiffUtil.calculateDiff(usersDiffCallback)
         filteredUserList.clear()
         filteredUserList.addAll(newFilteredUsers)
+        diffResult.dispatchUpdatesTo(this)
 
-        if (filterMap != map){
-            notifyDataSetChanged()
-            filterMap = map
-        } else notifyItemRangeChanged(oldSize,newSize)
     }
 
 

--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -87,7 +87,6 @@ class MembersFragment : BaseFragment() {
             }
         }
         rvMembers.apply {
-            Log.d("MembersAdapter", "onActivityCreated: rvMembers = init")
             layoutManager = LinearLayoutManager(context)
             addLoadMoreListener(this)
             adapter = MembersAdapter(userList, ::openUserProfile)
@@ -98,11 +97,17 @@ class MembersFragment : BaseFragment() {
         super.onActivityCreated(savedInstanceState)
         setHasOptionsMenu(true)
         rvAdapter = MembersAdapter(arrayListOf<User>(), ::openUserProfile)
-        srlMembers.setOnRefreshListener { fetchNewest(true) }
+        srlMembers.setOnRefreshListener {
+            if(!isLoading) {
+                fetchNewest(true)
+                isLoading = true
+            }
+        }
 
         membersViewModel.successful.observe(viewLifecycleOwner, Observer { successful ->
             (activity as MainActivity).hideProgressDialog()
             srlMembers.isRefreshing = false
+            isLoading = false
             pbMembers.visibility = View.INVISIBLE
             if (successful != null) {
                 if (successful) {
@@ -133,7 +138,6 @@ class MembersFragment : BaseFragment() {
                         Snackbar.make(it, membersViewModel.message, Snackbar.LENGTH_LONG).show()
                     }
                 }
-                isLoading = false
             }
         })
         fetchNewest(true)
@@ -151,7 +155,6 @@ class MembersFragment : BaseFragment() {
         recyclerView.addOnScrollListener(object :
                 EndlessRecyclerScrollListener(recyclerView.layoutManager as LinearLayoutManager) {
             override fun onLoadMore(page: Int, totalItemsCount: Int) {
-                Log.d(MembersFragment.toString(), "onLoadMore: ")
                 if (!isLoading){
                     fetchNewest(false)
                     isLoading = true

--- a/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/MembersFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import android.app.Activity.RESULT_OK
+import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -23,10 +24,13 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_members.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
+import org.systers.mentorship.remote.requests.PaginationRequest
 import org.systers.mentorship.utils.Constants
 import org.systers.mentorship.utils.Constants.FILTER_MAP
 import org.systers.mentorship.utils.Constants.FILTER_REQUEST_CODE
+import org.systers.mentorship.utils.Constants.ITEMS_PER_PAGE
 import org.systers.mentorship.utils.Constants.SORT_KEY
+import org.systers.mentorship.utils.EndlessRecyclerScrollListener
 import org.systers.mentorship.view.activities.FilterActivity
 import org.systers.mentorship.view.activities.MainActivity
 import org.systers.mentorship.view.activities.MemberProfileActivity
@@ -50,6 +54,8 @@ class MembersFragment : BaseFragment() {
         ViewModelProviders.of(this).get(MembersViewModel::class.java)
     }
     private lateinit var rvAdapter: MembersAdapter
+    private var isLoading = false
+    private var isRecyclerView = false
     private var filterMap = hashMapOf(SORT_KEY to SortValues.REGISTRATION_DATE.name)
 
     override fun getLayoutResourceId(): Int = R.layout.fragment_members
@@ -73,7 +79,7 @@ class MembersFragment : BaseFragment() {
     }
 
     fun searchUsers(query: String){
-        var userList=mutableListOf<User>()
+        var userList = arrayListOf<User>()
         for(user in membersViewModel.userList){
             // ""+ to convert String to CharSequence
             if ((""+user.username).contains(query, ignoreCase = true)){
@@ -81,7 +87,9 @@ class MembersFragment : BaseFragment() {
             }
         }
         rvMembers.apply {
+            Log.d("MembersAdapter", "onActivityCreated: rvMembers = init")
             layoutManager = LinearLayoutManager(context)
+            addLoadMoreListener(this)
             adapter = MembersAdapter(userList, ::openUserProfile)
         }
         tvEmptyList.visibility = View.GONE
@@ -89,30 +97,34 @@ class MembersFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         setHasOptionsMenu(true)
-        rvAdapter = MembersAdapter(listOf(), ::openUserProfile)
-        srlMembers.setOnRefreshListener { fetchNewest() }
+        rvAdapter = MembersAdapter(arrayListOf<User>(), ::openUserProfile)
+        srlMembers.setOnRefreshListener { fetchNewest(true) }
 
         membersViewModel.successful.observe(viewLifecycleOwner, Observer { successful ->
             (activity as MainActivity).hideProgressDialog()
             srlMembers.isRefreshing = false
+            pbMembers.visibility = View.INVISIBLE
             if (successful != null) {
                 if (successful) {
-                    rvAdapter.setData(membersViewModel.userList)
-                    rvAdapter.filter(filterMap)
 
+                    rvAdapter.updateUsersList(filterMap,membersViewModel.userList)
                     if (membersViewModel.userList.isEmpty()) {
                         tvEmptyList.text = getString(R.string.empty_members_list)
                         rvMembers.visibility = View.GONE
                     } else {
-                        rvMembers.apply {
-                            layoutManager = LinearLayoutManager(context)
-                            adapter = MembersAdapter(membersViewModel.userList, ::openUserProfile)
-                            runLayoutAnimation(this)
+                        if (!isRecyclerView){
+                            rvMembers.apply {
+                                layoutManager = LinearLayoutManager(context)
+                                adapter = MembersAdapter(membersViewModel.userList, ::openUserProfile)
+                                addLoadMoreListener(this)
+                                runLayoutAnimation(this)
 
-                            val dividerItemDecoration = DividerItemDecoration(
-                                    this.context, DividerItemDecoration.VERTICAL)
-                            addItemDecoration(dividerItemDecoration)
-                            adapter = rvAdapter
+                                val dividerItemDecoration = DividerItemDecoration(
+                                        this.context, DividerItemDecoration.VERTICAL)
+                                addItemDecoration(dividerItemDecoration)
+                                adapter = rvAdapter
+                                isRecyclerView = true
+                            }
                         }
                         tvEmptyList.visibility = View.GONE
                     }
@@ -121,10 +133,10 @@ class MembersFragment : BaseFragment() {
                         Snackbar.make(it, membersViewModel.message, Snackbar.LENGTH_LONG).show()
                     }
                 }
+                isLoading = false
             }
         })
-
-        fetchNewest()
+        fetchNewest(true)
     }
 
     private fun runLayoutAnimation(recyclerView: RecyclerView) {
@@ -133,6 +145,20 @@ class MembersFragment : BaseFragment() {
                 R.anim.layout_fall_down)
         recyclerView.adapter?.notifyDataSetChanged()
         recyclerView.scheduleLayoutAnimation()
+    }
+
+    private fun addLoadMoreListener(recyclerView: RecyclerView) {
+        recyclerView.addOnScrollListener(object :
+                EndlessRecyclerScrollListener(recyclerView.layoutManager as LinearLayoutManager) {
+            override fun onLoadMore(page: Int, totalItemsCount: Int) {
+                Log.d(MembersFragment.toString(), "onLoadMore: ")
+                if (!isLoading){
+                    fetchNewest(false)
+                    isLoading = true
+                    pbMembers.visibility = View.VISIBLE
+                }
+            }
+        })
     }
 
     private fun openUserProfile(memberId: Int, sharedImageView: ImageView, sharedTextView: TextView) {
@@ -164,7 +190,7 @@ class MembersFragment : BaseFragment() {
                 true
             }
             R.id.menu_refresh -> {
-                fetchNewest()
+                fetchNewest(true)
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -176,7 +202,7 @@ class MembersFragment : BaseFragment() {
         if (requestCode == FILTER_REQUEST_CODE && resultCode == RESULT_OK) {
             filterMap = data?.extras?.get(FILTER_MAP) as HashMap<String, String>?
                     ?: hashMapOf(SORT_KEY to SortValues.REGISTRATION_DATE.name)
-            rvAdapter.filter(filterMap)
+            rvAdapter.updateUsersList(filterMap,membersViewModel.userList)
         }
     }
 
@@ -186,9 +212,9 @@ class MembersFragment : BaseFragment() {
         REGISTRATION_DATE
     }
 
-    private fun fetchNewest()  {
-        srlMembers.isRefreshing = true
-        membersViewModel.getUsers()
+    private fun fetchNewest(isRefresh: Boolean)  {
+        srlMembers.isRefreshing = isRefresh
+        membersViewModel.getUsers(isRefresh)
     }
 
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/MembersViewModel.kt
@@ -11,7 +11,9 @@ import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
+import org.systers.mentorship.remote.requests.PaginationRequest
 import org.systers.mentorship.utils.CommonUtils
+import org.systers.mentorship.utils.Constants.ITEMS_PER_PAGE
 import retrofit2.HttpException
 import java.io.IOException
 import java.util.concurrent.TimeoutException
@@ -26,21 +28,28 @@ class MembersViewModel : ViewModel() {
     private val userDataManager: UserDataManager = UserDataManager()
 
     val successful: MutableLiveData<Boolean> = MutableLiveData()
+    var currentPage = 1
     lateinit var message: String
-    lateinit var userList: List<User>
+    var userList: ArrayList<User> = arrayListOf()
+
 
     /**
      * Fetches users list from getUsers method of the UserService
      */
     @SuppressLint("CheckResult")
-    fun getUsers() {
-        userDataManager.getUsers()
+    fun getUsers(isRefresh: Boolean) {
+        if (isRefresh) {
+            userList.clear()
+            currentPage = 1
+        }
+        userDataManager.getUsers(paginationRequest = PaginationRequest(currentPage,ITEMS_PER_PAGE))
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeWith(object : DisposableObserver<List<User>>() {
                     override fun onNext(userListResponse: List<User>) {
-                        userList = userListResponse
+                        userList.addAll(userListResponse)
                         successful.value = true
+                        currentPage++
                     }
 
                     override fun onError(throwable: Throwable) {

--- a/app/src/main/res/layout/fragment_members.xml
+++ b/app/src/main/res/layout/fragment_members.xml
@@ -29,8 +29,8 @@
 
             <ProgressBar
                 android:id="@+id/pbMembers"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="@dimen/progress_bar_size_small"
+                android:layout_height="@dimen/progress_bar_size_small"
                 android:visibility="invisible"
                 android:layout_marginBottom="?attr/actionBarSize"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_members.xml
+++ b/app/src/main/res/layout/fragment_members.xml
@@ -10,15 +10,36 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rvMembers"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:scrollbars="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvMembers"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"
+                android:paddingBottom="128dp"
+                android:clipToPadding="false"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <ProgressBar
+                android:id="@+id/pbMembers"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:visibility="invisible"
+                android:layout_marginBottom="?attr/actionBarSize"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,5 @@
     <dimen name="margin_big">32dp</dimen>
     <dimen name="test_size_title">18sp</dimen>
     <dimen name="test_size_title_big">24sp</dimen>
+    <dimen name="progress_bar_size_small">24dp</dimen>
 </resources>


### PR DESCRIPTION
### Description
Pagination Feature added to the member's screen and When scrolling, fetch more users and fill the list (while showing a loader indicator).

I have changed the default items per page to 20 because 10 items are already visible on the first screen in my device and then load more called on the first start. Well this cal be changed later as I have added a constant value in the utils package

Added some changes to the user classes and added 3 new Files to the project directory i.e. 
**EndlessRecyclerview class** for easy load more implementation in recycler view
**PaginationRequest class** for adding pagination information while accessing new users 
**UsersDiffCallback class** for better performance of members screen recycler view, this class helps in the automatic update of  the  adapter data changes



Fixes #709 

### Type of Change:

- Code
- User Interface
- Documentation



### How Has This Been Tested?
This feature has been tested on the emulator and physical device. Gif related to the feature is given below which uses the cloud server. This feature is well tested with changing/applying new filters and everything works fine.

![GIF-200603_072157](https://user-images.githubusercontent.com/41780639/83587302-64896b80-a56c-11ea-9bd3-f23fe941a887.gif)




### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] I have written Kotlin Docs whenever is applicable


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes