### PR TITLE
feat: back button takes to LoginActivity from SignUpActivity

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -53,7 +53,6 @@ class LoginActivity : BaseActivity() {
         btnSignUp.setOnClickListener {
             intent = Intent(this, SignUpActivity::class.java)
             startActivity(intent)
-            finish()
         }
 
         tiPassword.editText?.setOnEditorActionListener { _, actionId, _ ->


### PR DESCRIPTION
### Description
The back button takes to the LoginActivity from the SignUpActivity on being pressed.

Fixes #645 

### Type of Change:
**Delete irrelevant options.**
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on Redmi 8A

![WhatsApp-Video-2020-06-11-at-725](https://user-images.githubusercontent.com/59681444/84407129-09204300-ac28-11ea-8458-d8169d1e0482.gif)




### Checklist:
**Delete irrelevant options.**

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
