### PR TITLE
Fix#649 Zulip and GitHub buttons in about acivity

### DIFF
--- a/app/src/main/res/drawable/ic_code_of_conduct.xml
+++ b/app/src/main/res/drawable/ic_code_of_conduct.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/app/src/main/res/drawable/ic_code_of_conduct.xml
+++ b/app/src/main/res/drawable/ic_code_of_conduct.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path

--- a/app/src/main/res/drawable/ic_github.xml
+++ b/app/src/main/res/drawable/ic_github.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_github.xml
+++ b/app/src/main/res/drawable/ic_github.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_privacy.xml
+++ b/app/src/main/res/drawable/ic_privacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_privacy.xml
+++ b/app/src/main/res/drawable/ic_privacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_terms_and_condition.xml
+++ b/app/src/main/res/drawable/ic_terms_and_condition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_terms_and_condition.xml
+++ b/app/src/main/res/drawable/ic_terms_and_condition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_web.xml
+++ b/app/src/main/res/drawable/ic_web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_web.xml
+++ b/app/src/main/res/drawable/ic_web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:tint="#fff"
     android:viewportWidth="24"
     android:viewportHeight="24">

--- a/app/src/main/res/drawable/ic_zulip.xml
+++ b/app/src/main/res/drawable/ic_zulip.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="@dimen/ico_size_about_actvt"
+    android:height="@dimen/ico_size_about_actvt"
     android:viewportWidth="256"
     android:viewportHeight="298">
   <path

--- a/app/src/main/res/drawable/ic_zulip.xml
+++ b/app/src/main/res/drawable/ic_zulip.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
-    android:width="2148dp"
-    android:height="2500dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="256"
     android:viewportHeight="298">
   <path

--- a/app/src/main/res/drawable/ic_zulip.xml
+++ b/app/src/main/res/drawable/ic_zulip.xml
@@ -1,7 +1,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
-    android:width="@dimen/ico_size_about_actvt"
-    android:height="@dimen/ico_size_about_actvt"
+    android:width="@dimen/ico_size_50dp"
+    android:height="@dimen/ico_size_50dp"
     android:viewportWidth="256"
     android:viewportHeight="298">
   <path

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -90,7 +90,7 @@
 
                         <ImageView
                             android:layout_width="114dp"
-                            android:layout_height="50dp"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_github" />

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -67,8 +67,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnGit"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -109,8 +109,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnSlack"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -152,8 +152,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnWebsite"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -194,8 +194,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnTermsCondition"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -237,8 +237,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnprivacypolicy"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -279,8 +279,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btncodeofconduct"
-                    android:layout_width="@dimen/cardView_dimensions_about_act"
-                    android:layout_height="@dimen/cardView_dimensions_about_act"
+                    android:layout_width="@dimen/cardView_dimen_120"
+                    android:layout_height="@dimen/cardView_dimen_120"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -63,13 +63,12 @@
                 android:layout_height="wrap_content"
                 android:alignmentMode="alignMargins"
                 android:columnCount="2"
-                android:padding="14dp"
-                >
+                android:padding="14dp">
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnGit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -89,16 +88,17 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_github" />
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/our_github_link"
                             android:textColor="#fff"
                             android:textSize="14sp"
@@ -109,8 +109,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnSlack"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -130,7 +130,7 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             android:padding="8dp"
@@ -138,9 +138,10 @@
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/systers_open_source_zulip"
                             android:textColor="#fff"
                             android:textSize="14sp"
@@ -151,8 +152,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnWebsite"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -172,16 +173,17 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_web" />
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/our_website"
                             android:textColor="#fff"
                             android:textSize="14sp"
@@ -192,8 +194,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnTermsCondition"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -213,16 +215,18 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_small"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_terms_and_condition" />
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/terms_and_conditions"
                             android:textColor="#fff"
                             android:textSize="14sp"
@@ -233,8 +237,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnprivacypolicy"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -254,16 +258,17 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_privacy" />
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/privacy_policy"
                             android:textColor="#fff"
                             android:textSize="14sp"
@@ -274,8 +279,8 @@
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btncodeofconduct"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/cardView_dimensions_about_act"
+                    android:layout_height="@dimen/cardView_dimensions_about_act"
                     android:layout_columnWeight="1"
                     android:layout_gravity="fill"
                     android:layout_margin="20dp"
@@ -295,16 +300,17 @@
 
                         <ImageView
                             android:layout_width="match_parent"
-                            android:layout_height="@dimen/ico_height_about_actvt"
+                            android:layout_height="0dp"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_code_of_conduct" />
 
                         <androidx.appcompat.widget.AppCompatTextView
                             android:layout_width="match_parent"
-                            android:layout_height="38dp"
+                            android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center"
+                            android:padding="@dimen/padding_small"
                             android:text="@string/code_of_conduct"
                             android:textColor="#fff"
                             android:textSize="14sp"

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -62,10 +62,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:alignmentMode="alignMargins"
-
                 android:columnCount="2"
                 android:padding="14dp"
-                android:rowCount="2">
+                >
 
                 <androidx.cardview.widget.CardView
                     android:id="@+id/btnGit"
@@ -89,8 +88,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_github" />
@@ -130,8 +129,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             android:padding="8dp"
@@ -172,8 +171,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_web" />
@@ -213,8 +212,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_terms_and_condition" />
@@ -254,8 +253,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_privacy" />
@@ -295,8 +294,8 @@
                         android:orientation="vertical">
 
                         <ImageView
-                            android:layout_width="114dp"
-                            android:layout_height="0dp"
+                            android:layout_width="match_parent"
+                            android:layout_height="@dimen/ico_height_about_actvt"
                             android:layout_gravity="center"
                             android:layout_weight="3"
                             app:srcCompat="@drawable/ic_code_of_conduct" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,8 +10,8 @@
     <dimen name="margin_medium">24dp</dimen>
     <dimen name="margin_big">32dp</dimen>
     <dimen name="padding_small">10dp</dimen>
-    <dimen name="cardView_dimensions_about_act">120dp</dimen>
+    <dimen name="cardView_dimen_120">120dp</dimen>
     <dimen name="test_size_title">18sp</dimen>
     <dimen name="test_size_title_big">24sp</dimen>
-    <dimen name="ico_size_about_actvt">50dp</dimen>
+    <dimen name="ico_size_50dp">50dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,5 @@
     <dimen name="margin_big">32dp</dimen>
     <dimen name="test_size_title">18sp</dimen>
     <dimen name="test_size_title_big">24sp</dimen>
+    <dimen name="ico_height_about_actvt">50dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,7 +9,9 @@
     <dimen name="margin_normal">16dp</dimen>
     <dimen name="margin_medium">24dp</dimen>
     <dimen name="margin_big">32dp</dimen>
+    <dimen name="padding_small">10dp</dimen>
+    <dimen name="cardView_dimensions_about_act">120dp</dimen>
     <dimen name="test_size_title">18sp</dimen>
     <dimen name="test_size_title_big">24sp</dimen>
-    <dimen name="ico_height_about_actvt">50dp</dimen>
+    <dimen name="ico_size_about_actvt">50dp</dimen>
 </resources>


### PR DESCRIPTION
### Description
Fixing the size of Zulip and GitHub buttons in the About activity.

Fixes #649 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
screenshot before changes
![bfr](https://user-images.githubusercontent.com/31371219/85074619-25d6f080-b1bd-11ea-840a-2cbf7cc9bbc4.jpeg)


screenshot after changes
![buttons about activity](https://user-images.githubusercontent.com/31371219/85075114-f4125980-b1bd-11ea-92c3-875d04a9a91d.jpeg)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
