### PR TITLE
fix: Bottom Navigation Tab Reselected Bug

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : BaseActivity() {
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
         bottomNavigation.setOnNavigationItemSelectedListener(mOnNavigationItemSelectedListener)
+        bottomNavigation.setOnNavigationItemReselectedListener {  }
 
         if (savedInstanceState == null) {
             showHomeFragment()


### PR DESCRIPTION
### Description
After the fix, Fragment is not replaced on reselecting the current fragment. This is done by adding onNavigationItemReselectedListener.

Fixes #724

### Type of Change:
**Delete irrelevant options.**
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
![frag](https://user-images.githubusercontent.com/59681444/85205785-2a291800-b33b-11ea-849f-747d7489a99f.gif)


Tested Locally on Redmi 8A
Android 9

### Checklist:
**Delete irrelevant options.**
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
