### PR TITLE
PR for issue #665

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
+                app:expandedTitleTextAppearance="@style/ExpandedToolbarTextStyle"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 app:toolbarId="@+id/toolbar">
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
+                app:expandedTitleTextAppearance="@style/ExpandedToolbarTextStyle"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 app:toolbarId="@+id/toolbar">
 
@@ -34,14 +35,14 @@
                     android:layout_height="match_parent"
                     android:scaleType="centerCrop"
                     app:layout_collapseMode="parallax"
-                    app:srcCompat="@drawable/prominent_nav_bar"/>
+                    app:srcCompat="@drawable/prominent_nav_bar" />
 
                 <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     app:layout_collapseMode="pin"
-                    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+                    app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 
@@ -66,10 +67,10 @@
         android:id="@+id/bottomNavigation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:labelVisibilityMode="labeled"
-        android:layout_marginEnd="0dp"
         android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
+        app:labelVisibilityMode="labeled"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -57,4 +57,9 @@
         <item name="android:background">?selectableItemBackground</item>
         <item name="android:gravity">center_vertical</item>
     </style>
+
+    <style name="ExpandedToolbarTextStyle">
+        <item name="android:textSize">26sp</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -57,4 +57,7 @@
         <item name="android:background">?selectableItemBackground</item>
         <item name="android:gravity">center_vertical</item>
     </style>
+    <style name="ExpandedToolbarTextStyle">
+        <item name="android:textSize">26sp</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Description
On the mentorship requests page, the toolbar title used to get hidden on small screen devices. 

Fixes # [ISSUE]

### Type of Change:
 - added attribute **app:expandedTitleTextAppearance** for collapsing toolbar layout in activity_main.xml 
- added a new style corresponding to the above attribute in styles.xml. Added attribute **textSize=_"26sp"_**


### How Has This Been Tested?
I ran the app on devices with different screen sizes. First : _1440 x 2560 (560dpi)_ screen and Second : _480 x 800 (hdpi)_ screen. The second device screen size is the lowest possible assumption I have made. Corresponding to textSize="26sp", the bug has been fixed. Also, the _bug persists at 28sp_, that's why chose 26sp to be the optimal text size. 


### Checklist:
**Delete irrelevant options.**

- My PR follows the style guidelines of this project
- I have performed a self-review of my own code or materials
- Any dependent changes have been merged

**Code/Quality Assurance Only**
- My changes generate no new warnings