### PR TITLE
fix: Update collapsing toolbar text size

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="true"
+                app:expandedTitleTextAppearance="@style/ExpandedToolbarTextStyle"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 app:toolbarId="@+id/toolbar">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -15,4 +15,5 @@
     <dimen name="test_size_title_big">24sp</dimen>
     <dimen name="progress_bar_size_small">24dp</dimen>
     <dimen name="ico_size_50dp">50dp</dimen>
+    <dimen name="expanded_toolbar_text_size">26sp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -57,4 +57,8 @@
         <item name="android:background">?selectableItemBackground</item>
         <item name="android:gravity">center_vertical</item>
     </style>
+
+    <style name="ExpandedToolbarTextStyle">
+        <item name="android:textSize">26sp</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -59,6 +59,6 @@
     </style>
 
     <style name="ExpandedToolbarTextStyle">
-        <item name="android:textSize">26sp</item>
+        <item name="android:textSize">@dimen/expanded_toolbar_text_size</item>
     </style>
 </resources>


### PR DESCRIPTION
### Description
On the mentorship requests page, the toolbar title used to get hidden on small screen devices.

Fixes [#665](https://github.com/anitab-org/mentorship-android/issues/665)

### Type of Change:
- added attribute app:expandedTitleTextAppearance for collapsing toolbar layout in activity_main.xml
- added a new style corresponding to the above attribute in styles.xml. Added attribute textSize="26sp"

### How Has This Been Tested?
I ran the app on devices with different screen sizes. First : 1440 x 2560 (560dpi) screen and Second : 480 x 800 (hdpi) screen. The second device screen size is the lowest possible assumption I have made. Corresponding to textSize="26sp", the bug has been fixed. Also, the bug persists at 28sp, that's why I chose 26sp to be the optimal text size.
Screenshots for changes implemented : 
#### Before this PR :
<img src="https://user-images.githubusercontent.com/46836295/89123061-1ea83f80-d4ea-11ea-9469-e72900c49453.jpg" width="460" height="960">

#### After this PR :
<img src="https://user-images.githubusercontent.com/46836295/89123103-6fb83380-d4ea-11ea-8df2-e84ce0ef46f8.jpg" width="460" height="960">

### Checklist:

- My PR follows the style guidelines of this project
- I have performed a self-review of my own code or materials
- Any dependent changes have been merged

**Code/Quality Assurance Only**
- My changes generate no new warnings