### PR TITLE
Send request ux improved

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -42,7 +42,7 @@ class MemberProfileActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     setCurrentUser(profileViewModel.user)
-                    if (currentUser.availableToMentor!=true && currentUser.needMentoring!=true) {
+                    if (!currentUser.availableToMentor!! && !currentUser.needMentoring!!) {
                         btnSendRequest.setBackgroundColor(Color.GRAY)
                     }
                 } else {
@@ -62,7 +62,7 @@ class MemberProfileActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     setUserProfile(memberProfileViewModel.userProfile)
-                    if (userProfile.availableToMentor!=true && userProfile.needMentoring!=true) {
+                    if (!userProfile.availableToMentor!! && !userProfile.needMentoring!!) {
                         btnSendRequest.setBackgroundColor(Color.GRAY)
                     }
                 } else {
@@ -82,9 +82,9 @@ class MemberProfileActivity : BaseActivity() {
 
             if (this::currentUser.isInitialized && this::userProfile.isInitialized) {
 
-                if (currentUser.availableToMentor == true || currentUser.needMentoring == true) {
+                if (currentUser.availableToMentor!! || currentUser.needMentoring!!) {
 
-                    if (userProfile.availableToMentor == true || userProfile.availableToMentor == true) {
+                    if (userProfile.availableToMentor!! || userProfile.availableToMentor!!) {
                         val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
                         intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
                         intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
@@ -164,8 +164,6 @@ class MemberProfileActivity : BaseActivity() {
                 tvUsername, getString(R.string.username), user.username)
         setTextViewStartingWithBoldSpan(
                 tvSlackUsername, getString(R.string.slack_username), user.slackUsername)
-        if (!user.availableToMentor!! && !user.needMentoring!!)
-            btnSendRequest.isEnabled = false
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/MemberProfileActivity.kt
@@ -1,12 +1,14 @@
 package org.systers.mentorship.view.activities
 
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
-import com.google.android.material.snackbar.Snackbar
 import android.view.MenuItem
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_member_profile.*
 import org.systers.mentorship.R
 import org.systers.mentorship.models.User
@@ -40,6 +42,9 @@ class MemberProfileActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     setCurrentUser(profileViewModel.user)
+                    if (currentUser.availableToMentor!=true && currentUser.needMentoring!=true) {
+                        btnSendRequest.setBackgroundColor(Color.GRAY)
+                    }
                 } else {
                     Snackbar.make(getRootView(), profileViewModel.message, Snackbar.LENGTH_LONG)
                             .show()
@@ -57,6 +62,9 @@ class MemberProfileActivity : BaseActivity() {
             if (successful != null) {
                 if (successful) {
                     setUserProfile(memberProfileViewModel.userProfile)
+                    if (userProfile.availableToMentor!=true && userProfile.needMentoring!=true) {
+                        btnSendRequest.setBackgroundColor(Color.GRAY)
+                    }
                 } else {
                     Snackbar.make(getRootView(), memberProfileViewModel.message, Snackbar.LENGTH_LONG)
                             .show()
@@ -70,18 +78,29 @@ class MemberProfileActivity : BaseActivity() {
 
         fetchNewest()
 
-
         btnSendRequest.setOnClickListener {
-            if(userProfile?.availableToMentor ?: false && !(userProfile?.needMentoring ?:false)
-                    && (currentUser?.availableToMentor ?: false && !(currentUser?.needMentoring ?:false))){
-                Snackbar.make(getRootView(), getString(R.string.both_users_only_available_to_mentor), Snackbar.LENGTH_LONG)
-                        .show()
-            } else{
-              val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
-                intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
-                intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
-                startActivity(intent)
-            }
+
+            if (this::currentUser.isInitialized && this::userProfile.isInitialized) {
+
+                if (currentUser.availableToMentor == true || currentUser.needMentoring == true) {
+
+                    if (userProfile.availableToMentor == true || userProfile.availableToMentor == true) {
+                        val intent = Intent(this@MemberProfileActivity, SendRequestActivity::class.java)
+                        intent.putExtra(SendRequestActivity.OTHER_USER_ID_INTENT_EXTRA, userProfile.id)
+                        intent.putExtra(SendRequestActivity.OTHER_USER_NAME_INTENT_EXTRA, userProfile.name)
+                        startActivity(intent)
+
+                    } else Snackbar.make(getRootView(),
+                            getString(R.string.user_not_available_to_mentor_or_mentee),
+                            Snackbar.LENGTH_LONG).show()
+
+                } else Snackbar.make(getRootView(),
+                        getString(R.string.you_not_available_to_mentor_or_mentee),
+                        Snackbar.LENGTH_LONG).show()
+
+            } else Snackbar.make(getRootView(),
+                    getString(R.string.error_something_went_wrong),
+                    Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
     <string name="only_available_to_mentor">Only available to mentor</string>
     <string name="only_available_to_mentee">Only available to be a mentee</string>
     <string name="not_available_to_mentor_or_mentee">Not available to be a mentor or a mentee</string>
+    <string name="user_not_available_to_mentor_or_mentee">User is not available to be a mentor or a mentee</string>
+    <string name="you_not_available_to_mentor_or_mentee">You are not available to be a mentor or a mentee</string>
     <string name="both_users_only_available_to_mentor">This request is not possible because both users are only ‘available to mentor\'</string>
     <string name="user_photo">User Photo</string>
     <string name="pending">Pending</string>


### PR DESCRIPTION
### Description
Improved UX based on the related issue.
Added snack bar with the grey button if currentUser is neither available to mentor or mentee and vice-versa for the selected user. Now sendRequest button only opens the SendRequestActivity if both the users have one of the enabled options in the settings i.e.  availableToMentor or needsMentoring

Fixes #98 

### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
This is test for all the possible cases in sending the request to the user in an android emulator. I have added 2 possible screenshots in send request if the user is not available to be a mentor or mentee and same if the selected member is not available.

![Screenshot_2020-07-26-02-57-36-466_org systers 1](https://user-images.githubusercontent.com/41780639/88466919-df2c9280-ceee-11ea-86f6-cf16b39ee274.png) ![Screenshot_2020-07-26-02-58-04-534_org systers 1 (2)](https://user-images.githubusercontent.com/41780639/88466920-e18eec80-ceee-11ea-88ab-806c7a9e5e73.png)




### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged