### PR TITLE
Fix (Issue #781): Disabled the login button until the user has filled the credentials

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/LoginActivity.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import com.google.android.material.snackbar.Snackbar
 import android.view.inputmethod.EditorInfo
 import android.widget.Toast
@@ -28,6 +30,9 @@ class LoginActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
+
+        etUsername.addTextChangedListener(textWatcher)
+        etPassword.addTextChangedListener(textWatcher)
 
         loginViewModel.successful.observe(this, Observer {
             successful ->
@@ -67,6 +72,31 @@ class LoginActivity : BaseActivity() {
             if (tokenExpiredVal == 0)
                 Snackbar.make(getRootView(), "Session token expired, please login again", Snackbar.LENGTH_LONG).show()
         }catch (exception: Exception){}
+
+        checkFieldsForEmptyValues()
+    }
+
+    private fun checkFieldsForEmptyValues(){
+        val editText1: String? = etUsername.text.toString()
+        val editText2: String? = etPassword.text.toString()
+
+        /**
+         * Disables the button if one of the EditText field is empty
+         */
+        btnLogin.isEnabled = !(editText1.equals("") || editText2.equals(""))
+    }
+
+    private val textWatcher = object : TextWatcher {
+        override fun afterTextChanged(p0: Editable?) {
+            checkFieldsForEmptyValues()
+        }
+
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+        }
+
+        override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+        }
+
     }
 
     private fun validateCredentials() : Boolean {


### PR DESCRIPTION
### Description
I have made some changes such that the login button is disabled until the user has filled his/her credentials.
Added a textwatcher which checks for the empty fields (username and password) and disables/enables the login button accordingly.

Fixes #781 

### Type of Change:

- Code

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually tested on:
<ul>
<li>Smartphone: Realme X
<li>Android version: 10
</ul>

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes

![app](https://user-images.githubusercontent.com/55179845/91740912-98a71380-ebd1-11ea-8f93-ea9773c0d1a5.gif)