### PR TITLE
Fix:Set condition for password change button enabling

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/ChangePasswordFragment.kt
@@ -1,14 +1,18 @@
 package org.systers.mentorship.view.fragments
 
 import android.app.Dialog
+import android.content.DialogInterface
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import androidx.fragment.app.DialogFragment
 import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.Toast
+import com.google.android.material.textfield.TextInputEditText
 import kotlinx.android.synthetic.main.fragment_change_password.view.*
 import org.systers.mentorship.R
 import org.systers.mentorship.remote.requests.ChangePassword
@@ -56,12 +60,24 @@ class ChangePasswordFragment : DialogFragment() {
         builder.setNegativeButton(getString(R.string.cancel)) { dialog, _ ->
             dialog.cancel()
         }
-        return builder.create()
+        val passwordDialog = builder.create()
+        passwordDialog.setOnShowListener { passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = false }
+
+        changePasswordView.tilConfirmPassword.editText?.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(confirmPasswordEditable: Editable?) {
+                passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = confirmPasswordEditable!!.isNotEmpty()
+            }
+
+        })
+        return passwordDialog
     }
 
     override fun onResume() {
         super.onResume()
-
         val passwordDialog = dialog as? AlertDialog
         passwordDialog?.setCanceledOnTouchOutside(false)
         passwordDialog?.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener {


### PR DESCRIPTION
### Description
Added check on confirm password to enable the positive button of the change password dialog.
 
Fixes #573 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested on Redmi 8A(Android 9)
![mentorship](https://user-images.githubusercontent.com/59681444/92014629-2e2ada80-ed6d-11ea-80ac-bd3dad4c4094.gif)

### Checklist:
- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works