### PR TITLE
Feature (Fixes #739): Added GitHub Actions that run same steps as Travis CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+# This workflow executes the gradle build.
+# It is triggered on a push or a pull request on develop branch.
+# Generated APKs are uploaded as artifacts
+
+name: Build
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    name: Build and Generate APK artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Set up JDK
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+         java-version: 1.8
+
+      # Cache gradle to speed up the build
+      - name: Cache Gradle and Wrapper
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: cache-${{ runner.os }}-${{ matrix.jdk }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      
+      # Grant Permission to Execute gradlew
+      - name: Grant Permission to Execute
+        run: chmod +x gradlew
+      
+      # Build
+      - name: Build
+        run: bash ./gradlew build --stacktrace
+      
+      # Upload the generated APKs to the artifacts
+      - name: Upload APKs as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: APKs
+          path: |
+            app/build/outputs/apk/debug/app-debug.apk
+            app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/push_apks.yml
+++ b/.github/workflows/push_apks.yml
@@ -1,0 +1,65 @@
+# In this workflow, generated APKs are pushed to the anitab-orgs's mentorship-android repository's apk branch
+# This workflow is triggered when some changes are pushed to the anitab-org's mentorship android repository's develop branch
+
+name: Push APKs to apk branch
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+    name: Generate and push apk to apk branch
+    if: github.repository == 'anitab-org/mentorship-android'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      # Set up JDK
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+         java-version: 1.8
+
+      # Cache gradle
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: cache-${{ runner.os }}-${{ matrix.jdk }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      
+      # Grant Permission to Execute gradle
+      - name: Grant Permissions to Execute
+        run: chmod +x gradlew
+      
+      # Generate Debug and Release APKs
+      - name: Generate APKs
+        run: |
+          ./gradlew :app:assembleDebug --stacktrace
+          ./gradlew :app:assembleRelease --stacktrace
+        
+      - name: Upload APKs as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: APKs
+          path: |
+            app/build/outputs/apk/debug/app-debug.apk
+            app/build/outputs/apk/release/app-release-unsigned.apk
+      - name: Push APKs to apk branch
+        run: |
+          git config --global user.name "m-murad"
+          git config --global user.email "murad.kuka@gmail.com"
+          mkdir ~/apk
+          cp app/build/outputs/apk/debug/app-debug.apk ~/apk
+          cp app/build/outputs/apk/release/app-release-unsigned.apk ~/apk
+          git fetch origin
+          git checkout apk
+          mv ~/apk/app-debug.apk $GITHUB_WORKSPACE
+          mv ~/apk/app-release-unsigned.apk $GITHUB_WORKSPACE
+          git add .
+          git commit -m "APK update: GitHub Actions Build $GITHUB_RUN_ID by $GITHUB_ACTOR"
+          git push origin apk

--- a/.github/workflows/push_apks.yml
+++ b/.github/workflows/push_apks.yml
@@ -51,7 +51,7 @@ jobs:
             app/build/outputs/apk/release/app-release-unsigned.apk
       - name: Push APKs to apk branch
         run: |
-          git config --global user.name "m-murad"
+          git config --global user.name "anitab-org"
           git config --global user.email "opensource@anitab.org"
           mkdir ~/apk
           cp app/build/outputs/apk/debug/app-debug.apk ~/apk

--- a/.github/workflows/push_apks.yml
+++ b/.github/workflows/push_apks.yml
@@ -1,4 +1,4 @@
-# In this workflow, generated APKs are pushed to the anitab-orgs's mentorship-android repository's apk branch
+# In this workflow, generated APKs are pushed to the anitab-org's mentorship-android repository's apk branch
 # This workflow is triggered when some changes are pushed to the anitab-org's mentorship android repository's develop branch
 
 name: Push APKs to apk branch

--- a/.github/workflows/push_apks.yml
+++ b/.github/workflows/push_apks.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Push APKs to apk branch
         run: |
           git config --global user.name "m-murad"
-          git config --global user.email "murad.kuka@gmail.com"
+          git config --global user.email "opensource@anitab.org"
           mkdir ~/apk
           cp app/build/outputs/apk/debug/app-debug.apk ~/apk
           cp app/build/outputs/apk/release/app-release-unsigned.apk ~/apk


### PR DESCRIPTION
### Description
I have added GitHub Actions that run steps similar to Travis CI
I've added two workflows :
![Screenshot from 2020-09-08 17-22-59](https://user-images.githubusercontent.com/55179845/92475759-89d8e600-f1fb-11ea-9c3d-fc8bff1a4bbe.png)
- **build.yml** : This workflow executes gradle build on every push/pull request on develop branch
- **push_apks.yml** : This workflow pushes APKs to the apk branch of anitab-org/mentorship-android repository. This workflow is triggered only when changes are pushed on the develop branch of anitab-org/mentorship-android (Not on any other forked repositories).

I've also added following extra features:
- **Caching** : Gradle and wrapper is cached to ensure that the subsequent builds are faster
- **Artifacts** : Even though APKs are pushed to the apk branch only on successful merge or push to the main repository. Those generated APKs on each build can be accessed using the generated artifacts after the build workflow is executed successfully.

Fixes #739

### Type of Change:
- Code
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
- I have tested the build workflow and it's working perfectly fine!
- Build Screenshot:
![Screenshot from 2020-09-08 18-01-49](https://user-images.githubusercontent.com/55179845/92477013-7e86ba00-f1fd-11ea-9314-8ad4dc2d7a7f.png)

- Also I have ensured that the push_apk.yml logic is correct by testing it on a dummy repository.
- But I **couldn't** test the second workflow (pushing APKs to the apk branch) because it requires a push to the main repository (i.e. anitab-org/mentorship-android).
- **This can only be tested by merging this PR.**


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings