### PR TITLE
Keyboard in the Signup page

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -1,9 +1,11 @@
 package org.systers.mentorship.view.activities
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -49,7 +51,14 @@ class SignUpActivity : BaseActivity() {
         })
 
         tvTC.movementMethod = LinkMovementMethod.getInstance()
+        fun View.hideKeyboard(){
+            val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(this.windowToken, 0)
+        }
 
+        contentView.setOnClickListener {
+            it.hideKeyboard()
+        }
         btnSignUp.setOnClickListener {
 
             name = tiName.editText?.text.toString()
@@ -146,4 +155,6 @@ class SignUpActivity : BaseActivity() {
         startActivity(intent)
         finish()
     }
+
+
 }

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -9,7 +9,11 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:context="org.systers.mentorship.view.activities.SignUpActivity">
+        tools:context="org.systers.mentorship.view.activities.SignUpActivity"
+        android:id="@+id/contentView"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:clickable="true">
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tvSignUp"


### PR DESCRIPTION
### Description
The keyboard does not pop up anymore on the Signup page. The keyboard closes when tapped anywhere else other than the edit text field.

Fixes #63 

### Type of Change:

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested on a physical device(Redmi note 5 pro).
GIF-
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/48028414/92144511-7103b580-ee34-11ea-9302-e5e431de30aa.gif)



### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules