### PR TITLE
Added Alert to Feedback Section

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/FeedbackActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/FeedbackActivity.kt
@@ -1,5 +1,6 @@
 package org.systers.mentorship.view.activities
 
+import android.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Editable
@@ -149,6 +150,28 @@ class FeedbackActivity : BaseActivity(), View.OnClickListener {
     override fun onSupportNavigateUp(): Boolean {
         onBackPressed()
         return true
+    }
+
+    override fun onBackPressed() {
+
+        val builder = AlertDialog.Builder(this)
+        //set title for alert dialog
+        builder.setTitle("Alert")
+        //set message for alert dialog
+        builder.setMessage("Are you sure you want to Discard?")
+        builder.setIcon(android.R.drawable.ic_dialog_alert)
+        //performing positive action
+        builder.setPositiveButton("Yes"){dialogInterface, which ->
+            super.onBackPressed()
+        }
+        //performing cancel action
+        builder.setNeutralButton("Cancel"){dialogInterface , which ->
+        }
+        // Create the AlertDialog
+        val alertDialog: AlertDialog = builder.create()
+        // Set other dialog properties
+        alertDialog.setCancelable(false)
+        alertDialog.show()
     }
 
     override fun onClick(v: View?) {


### PR DESCRIPTION
### Description
An alert dialogue has been added to the feedback page. When the user taps on the back button to exit the feedback screen a dialogue pops up asking the user whether they want to discard their changes or not.

Fixes #672 

### Type of Change:
**Delete irrelevant options.**

- Code
- Outreach

**Code/Quality Assurance Only**

- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Tested on my device (Redmi Note 5 pro).
Video - 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/48028414/91895221-805bf500-ecb4-11ea-8bb0-f6cd477b117d.gif)

### Checklist:
**Delete irrelevant options.**

- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules