### PR TITLE
fix: Adding runtime checks to signup page for the email and confirm password

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/SignUpActivity.kt
@@ -2,6 +2,8 @@ package org.systers.mentorship.view.activities
 
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.text.method.LinkMovementMethod
 import android.view.View
 import android.widget.Toast
@@ -31,6 +33,7 @@ class SignUpActivity : BaseActivity() {
     private var isAvailableToMentor: Boolean = false
     private var needsMentoring: Boolean = false
     private var isAvailableForBoth: Boolean = false
+    private val emailPattern = "[a-zA-Z0-9._-]+@[a-z]+\\.+[a-z]+"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,12 +76,44 @@ class SignUpActivity : BaseActivity() {
         cbTC.setOnCheckedChangeListener { _, b ->
             btnSignUp.isEnabled = b
         }
+
+        validateDetailsOnRuntime()
     }
 
     override fun onDestroy() {
         super.onDestroy()
         signUpViewModel.successful.removeObservers(this)
         signUpViewModel.successful.value = null
+    }
+
+    private fun validateDetailsOnRuntime(){
+        tiEmail.editText?.addTextChangedListener(object : TextWatcher{
+            override fun afterTextChanged(s: Editable?) {
+                if(!s.toString().matches(emailPattern.toRegex())){
+                    tiEmail.editText?.error="Please Enter a valid email"
+                }
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            }
+
+        })
+        tiConfirmPassword.editText?.addTextChangedListener(object: TextWatcher{
+            override fun afterTextChanged(s: Editable?) {
+                if(!tiPassword.editText?.text.toString().contentEquals(s.toString())){
+                    tiConfirmPassword.editText?.error = "Passwords do not match"
+                }
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            }
+        })
     }
 
     private fun validateDetails(): Boolean {


### PR DESCRIPTION
# Description
This adds runtime validation for the email and confirm password.
This resolves 2nd and 3rd point of issue.

Fixes #782 

### Type of Change:
**Delete irrelevant options.**
- Code

**Code/Quality Assurance Only**
- Bugfix (non-breaking change which fixes an issue)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes