### PR TITLE
Fix : Fixed feedback screen validation error #987

### DIFF
--- a/app/src/main/java/org/systers/mentorship/view/activities/FeedbackActivity.kt
+++ b/app/src/main/java/org/systers/mentorship/view/activities/FeedbackActivity.kt
@@ -35,75 +35,9 @@ class FeedbackActivity : BaseActivity(), View.OnClickListener {
 
         //init email ID input field
         FeedbackpageEmail.isErrorEnabled = true
-        FeedbackpageEmail.error = getString(R.string.email_error)
-        FeedbackpageEmail.editText?.addTextChangedListener(object : TextWatcher{
-            override fun afterTextChanged(s: Editable?) {
-
-            }
-
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-
-            }
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                if (!FeedbackpageEmail.editText?.text.isNullOrEmpty()&&!isValidEmail(s!!))
-                {
-                    FeedbackpageEmail.isErrorEnabled = true
-                    FeedbackpageEmail.error = getString(R.string.valid_error)
-                    feedbackEmailErr = true
-                }
-                else
-                {   if (s.toString().isEmpty())
-                {
-                    FeedbackpageEmail.isErrorEnabled = true
-                    FeedbackpageEmail.error = getString(R.string.email_error)
-                    feedbackEmailErr = true
-                }
-                else
-                {
-                    FeedbackpageEmail.isErrorEnabled = false
-                    feedbackEmailErr = false
-                }
-                }
-            }
-
-        })
 
         //init message input field
         FeedbackPageMessage.isErrorEnabled = true
-        FeedbackPageMessage.error = getString(R.string.msg_error)
-        FeedbackPageMessage.editText?.addTextChangedListener(object : TextWatcher{
-            override fun afterTextChanged(s: Editable?) {
-
-            }
-
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-
-            }
-
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                if (s.toString().length > FeedbackPageMessage.counterMaxLength)
-                {
-                    FeedbackPageMessage.isErrorEnabled = true
-                    FeedbackPageMessage.error = getString(R.string.char_error)
-                    feedbackMsgErr = true
-                }
-                else
-                {
-                    if (s.toString().isEmpty())
-                    {
-                        FeedbackPageMessage.isErrorEnabled = true
-                        FeedbackPageMessage.error = getString(R.string.msg_error)
-                        feedbackMsgErr = true
-                    }
-                    else
-                    {
-                        FeedbackPageMessage.isErrorEnabled = false
-                        feedbackMsgErr = false
-                    }
-                }
-            }
-        })
 
         //init ratingBtnList, an arraylist of ImageButtons, it is going to be used to add rating and change image resource, see fun assignRating()
         ratingBtnList = ArrayList()
@@ -127,6 +61,8 @@ class FeedbackActivity : BaseActivity(), View.OnClickListener {
 
         //Final submit button
         FeedbackpageSendbtn.setOnClickListener {
+            validateInput()
+
             if (!feedbackEmailErr && !feedbackMsgErr && feedbackRating != 0) {
                 Toast.makeText(this, getString(R.string.feedback_thank), Toast.LENGTH_SHORT).show()
                 //add backend code for adding rating, category, message, email ID
@@ -144,6 +80,79 @@ class FeedbackActivity : BaseActivity(), View.OnClickListener {
     //fun used to validate email ID
     fun isValidEmail(target: CharSequence): Boolean {
         return !TextUtils.isEmpty(target) && Patterns.EMAIL_ADDRESS.matcher(target).matches()
+    }
+
+    private fun validateInput(){
+        if(FeedbackpageEmail.editText?.text.isNullOrEmpty()) FeedbackpageEmail.error = getString(R.string.email_error)
+        else if(! isValidEmail(FeedbackpageEmail.editText?.text!!)) FeedbackpageEmail.error = getString(R.string.valid_error)
+        else {
+            FeedbackpageEmail.isErrorEnabled = false
+            feedbackEmailErr = false
+        }
+
+        FeedbackpageEmail.editText?.addTextChangedListener(object : TextWatcher{
+            override fun afterTextChanged(s: Editable?) {
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                if (!FeedbackpageEmail.editText?.text.isNullOrEmpty()&&!isValidEmail(s!!)) {
+                    FeedbackpageEmail.isErrorEnabled = true
+                    FeedbackpageEmail.error = getString(R.string.valid_error)
+                    feedbackEmailErr = true
+                }
+                else {
+                    if (s.toString().isEmpty()) {
+                        FeedbackpageEmail.isErrorEnabled = true
+                        FeedbackpageEmail.error = getString(R.string.email_error)
+                        feedbackEmailErr = true
+                    }
+                    else {
+                        FeedbackpageEmail.isErrorEnabled = false
+                        feedbackEmailErr = false
+                    }
+                }
+            }
+        })
+
+        if(FeedbackPageMessage.editText?.text.isNullOrEmpty()) FeedbackPageMessage.error = getString(R.string.msg_error)
+        else if (FeedbackPageMessage.editText?.text.toString().length > FeedbackPageMessage.counterMaxLength) {
+            FeedbackPageMessage.error = getString(R.string.char_error)
+        }
+        else {
+            FeedbackPageMessage.isErrorEnabled = false
+            feedbackMsgErr = false
+        }
+
+        FeedbackPageMessage.editText?.addTextChangedListener(object : TextWatcher{
+            override fun afterTextChanged(s: Editable?) {
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                if (s.toString().length > FeedbackPageMessage.counterMaxLength) {
+                    FeedbackPageMessage.isErrorEnabled = true
+                    FeedbackPageMessage.error = getString(R.string.char_error)
+                    feedbackMsgErr = true
+                }
+                else {
+                    if (s.toString().isEmpty()) {
+                        FeedbackPageMessage.isErrorEnabled = true
+                        FeedbackPageMessage.error = getString(R.string.msg_error)
+                        feedbackMsgErr = true
+                    }
+                    else {
+                        FeedbackPageMessage.isErrorEnabled = false
+                        feedbackMsgErr = false
+                    }
+                }
+            }
+        })
     }
 
     override fun onSupportNavigateUp(): Boolean {


### PR DESCRIPTION
### Description
Validation of the input was occurring even when the user hadn't pressed send feedback button which showed unnecessary errors. Now the validation process starts only when the user presses send feedback button, and the corresponding errors are shown afterwards. If the input is correct while pressing the button then the feedback will be submitted automatically.

Fixes #987 

### Type of Change:

- Code

**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Tested on 2 different emulators and a physical device (Samsung Galaxy J6)

https://drive.google.com/file/d/1OU1JIXFHzHTgAFo50pF8Ua8MgSLqStlQ/view?usp=sharing

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings