### PR TITLE
Fix 1008 - Remove redundant app namespace on the login activity layout

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content">
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,6 @@
     android:layout_height="wrap_content">
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"


### PR DESCRIPTION
Description
The bug fix was to remove the redundant app namespace on the login activity layout. That has been removed as a fix for the defect. 
Fixes # [[1008]](https://github.com/anitab-org/mentorship-android/issues/1008)

Type of Change:
Code
Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
Verified the layout on rebuild, no downstream effects were seen. 

Checklist:
 My PR follows the style guidelines of this project
 I have performed a self-review of my own code or materials
 Code/Quality Assurance Only
 My changes generate no new warnings
 