### PR TITLE
 Docs: Limitng dimensions of an image in PR's and issues #1028

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,8 @@
 * When developing a new feature, include at least one test when applicable.
 * When submitting a PR, please follow [this template](PULL_REQUEST_TEMPLATE.md) (which will probably be already filled up once you create the PR).
 * When submitting a PR with changes to user interface (e.g.: new screen, ...), please add screenshots to the PR description.
+* When adding a screenshot ensure that it can be viewed properly on any device, to resize the image refer to [this link](https://stackoverflow.com/questions/14675913/changing-image-size-in-markdown).
+* When adding multiple screenshots try using tables. You can use [this](https://www.tablesgenerator.com/markdown_tables) markdown table generator.
 * When you are finished with your work, please squash your commits otherwise we will squash them on your PR (this can help us maintain a clear commit history). 
 * When creating an issue to report a bug in the project, please follow our [bug_report.md](ISSUE_TEMPLATE/bug_report.md) template.
 * Issues labeled as “First Timers Only” are meant for contributors who have not contributed to the project yet. Please choose other issues to contribute to, if you have already contributed to these type of issues.


### PR DESCRIPTION
### Description
Updated contributing.md and added suggestions to limit the dimensions of the image and to use markdown tables if required. 

Fixes #1028 

### Type of Change:

- Documentation

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
