### PR TITLE
Added Kotlin docs link in readme.md and contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 * You can join us on [AnitaB.org Open Source Zulip](https://anitab-org.zulipchat.com/).  Each active repo has its own stream to direct questions to (for example #powerup or #portal).  Mentorship System stream is [#mentorship-system](https://anitab-org.zulipchat.com/#narrow/stream/222534-mentorship-system).
 * Remember that this is an inclusive community, committed to creating a safe, positive environment.  See the full [Code of Conduct](http://www.systers.io/code-of-conduct.html).
 * Follow our [Commit Message Style Guide](https://github.com/anitab-org/mentorship-android/wiki/Commit-Message-Style-Guide) when you commit your changes.
+* Please follow Kotlin official docs for [Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html) to maintain a consistent code style in the repository.
 * Please consider raising an issue before submitting a pull request (PR) to solve a problem that is not present in our [issue tracker](https://github.com/anitab-org/mentorship-android/issues). This allows maintainers to first validate the issue you are trying to solve and also reference the PR to a specific issue.
 * When developing a new feature, include at least one test when applicable.
 * When submitting a PR, please follow [this template](PULL_REQUEST_TEMPLATE.md) (which will probably be already filled up once you create the PR).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Please read our [Contributing guidelines](https://github.com/anitab-org/mentorsh
 
 Please follow our [Commit Message Style Guide](https://github.com/anitab-org/mentorship-android/wiki/Commit-Message-Style-Guide) while sending PRs.
 
+Please follow Kotlin official docs for [Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)to maintain a consistent code style in the repository.
+
 ## Running the UI tests
 
 To run the existing UI tests follow the steps given below:


### PR DESCRIPTION
### Description
Fixes #1049

Added link to Kotlin official docs for Coding Conventions: https://kotlinlang.org/docs/reference/coding-conventions.html in  README.md and CONTRIBUTING.md.

### Type of Change:
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
README.md
![mentorship-issue](https://user-images.githubusercontent.com/54268438/106037545-d9fa0b80-60fc-11eb-99b0-147560b6aad7.JPG)

CONTRIBUTING.md
![mentorship-issue2 JPG](https://user-images.githubusercontent.com/54268438/106037551-dbc3cf00-60fc-11eb-924a-4ad0ba7ea60b.png)


### Checklist:
**Delete irrelevant options.**
- [x] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
