### PR TITLE
Fix:1065 Bottom members now visible while scrolling

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -53,7 +53,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true"
-            android:layout_marginBottom="@dimen/fab_button_visible"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <FrameLayout

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -18,8 +18,7 @@
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingBottom="56dp">
+            android:layout_height="match_parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
### Description
<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
Fixes bug where users at the bottom of the screen were not visible while scrolling.
Removed attribute `layout_marginBottom` from `activity_main.xml`.

Fixes #1065 
<img src = "https://user-images.githubusercontent.com/42745880/107815563-901a5200-6d99-11eb-915d-0526776ec43e.png"  height = "500" />

### Type of Change:
<!--- **Delete irrelevant options.** --->

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->


### Checklist:
<!--- **Delete irrelevant options.** --->

- [x] I have performed a self-review of my own code or materials
- [x] My PR follows the style guidelines of this project


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings

