### PR TITLE
Refactor: Initialised the isDone field in the task model rather than obtaining from the api

### DIFF
--- a/app/src/main/java/org/systers/mentorship/models/Task.kt
+++ b/app/src/main/java/org/systers/mentorship/models/Task.kt
@@ -18,7 +18,8 @@ import kotlinx.android.parcel.Parcelize
 data class Task(
         val id: Int,
         val description: String,
-        val isDone: Boolean,
         val createdAt: Float,
-        val completedAt: Float
-): Parcelable
+        val completedAt: Float?
+): Parcelable {
+    val isDone: Boolean = completedAt != null
+}


### PR DESCRIPTION
### Description
Initialised the is_done field using the completedAt field int the task model. completedAt field has null values => task is not done and when it has some timestamp => task was completed at that point of time, so using this relation i've done the initialisation.

Fixes #1087 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
on 2 different emulators and a physical device (Samsung Galaxy J-6)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
