### PR TITLE
Fix #714 Saving User Profile , Restricting Profile API Call Repeatedly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -73,4 +77,11 @@ dependencies {
     implementation Dependencies.lifecycle_viewmodel
     implementation Dependencies.app_intro
     implementation Dependencies.circule_image_view
+    //Room database
+    implementation Dependencies.room_run
+    kapt Dependencies.room_com
+    implementation Dependencies.room_support
+    testImplementation Dependencies.room_test
+    implementation Dependencies.lifecycle_common
+    implementation Dependencies.lifecycle_viewmodel_ktx
 }

--- a/app/src/main/java/org/systers/mentorship/applicationClass.kt
+++ b/app/src/main/java/org/systers/mentorship/applicationClass.kt
@@ -1,0 +1,9 @@
+package org.systers.mentorship
+
+import org.systers.mentorship.models.User
+
+class applicationClass {
+    companion object {
+        var user: User? = null
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/data/userProfileDao.kt
+++ b/app/src/main/java/org/systers/mentorship/data/userProfileDao.kt
@@ -1,0 +1,24 @@
+package org.systers.mentorship.data
+
+import androidx.lifecycle.LiveData
+import androidx.room.*
+import org.systers.mentorship.models.User
+
+
+@Dao
+interface userProfileDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun storeUserProfile(user: User)
+
+    @Update
+    suspend fun updateUser(user: User)
+
+    @Delete
+    suspend fun deleteUserProfile(user: User)
+
+    @Query("delete from userProfileTable")
+    suspend fun deleteAllUserData()
+
+    @Query("select * from userProfileTable")
+    fun getUserProfile(): LiveData<User>
+}

--- a/app/src/main/java/org/systers/mentorship/data/userProfileDatabase.kt
+++ b/app/src/main/java/org/systers/mentorship/data/userProfileDatabase.kt
@@ -1,0 +1,31 @@
+package org.systers.mentorship.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import android.content.Context
+import androidx.room.Room
+import org.systers.mentorship.models.User
+
+@Database(entities = [User::class],version = 1 , exportSchema = false)
+abstract class userProfileDatabase:RoomDatabase() {
+    abstract fun userProfileDao(): userProfileDao
+    companion object{
+        @Volatile
+        private var INSTANCE: userProfileDatabase?=null
+        fun getDatabase(context:Context): userProfileDatabase{
+            val tempInstance = INSTANCE
+            if(tempInstance!=null){
+                return tempInstance
+            }
+            synchronized(this){
+                val instance  = Room.databaseBuilder(
+                        context.applicationContext,
+                        userProfileDatabase::class.java,
+                        "userProfileDatabase"
+                ).build()
+                INSTANCE = instance
+                return instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/data/userProfileRepo.kt
+++ b/app/src/main/java/org/systers/mentorship/data/userProfileRepo.kt
@@ -1,0 +1,14 @@
+package org.systers.mentorship.data
+
+import androidx.lifecycle.LiveData
+import org.systers.mentorship.models.User
+
+class userProfileRepo(private val userProfileDao: userProfileDao) {
+    val getUserProfile: LiveData<User> = userProfileDao.getUserProfile()
+    suspend fun storeUserProfile(user: User){
+        userProfileDao.storeUserProfile(user)
+    }
+    suspend fun deleteUserProfile(){
+        userProfileDao.deleteAllUserData()
+    }
+}

--- a/app/src/main/java/org/systers/mentorship/models/User.kt
+++ b/app/src/main/java/org/systers/mentorship/models/User.kt
@@ -1,6 +1,8 @@
 package org.systers.mentorship.models
 
 import android.os.Parcelable
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import kotlinx.android.parcel.Parcelize
 
 /**
@@ -21,7 +23,9 @@ import kotlinx.android.parcel.Parcelize
  * @param slackUsername Slack username
  */
 @Parcelize
+@Entity(tableName="userProfileTable")
 data class User(
+        @PrimaryKey(autoGenerate = false)
         var id: Int? = null,
         var username: String? = null,
         var name: String? = null,

--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import org.systers.mentorship.R
+import org.systers.mentorship.applicationClass
 import org.systers.mentorship.databinding.FragmentEditProfileBinding
 import org.systers.mentorship.models.User
 import org.systers.mentorship.utils.EditProfileFragmentErrorStates
@@ -110,6 +111,7 @@ class EditProfileFragment : DialogFragment() {
             }
             if (currentUser != editProfileBinding.user && errors.isEmpty()) {
                 profileViewModel.updateProfile(editProfileBinding.user!!)
+                applicationClass.user = null
             } else if (currentUser == editProfileBinding.user && errors.isEmpty()) {
                 builder.dismiss()
             }

--- a/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/org/systers/mentorship/view/fragments/EditProfileFragment.kt
@@ -47,6 +47,7 @@ class EditProfileFragment : DialogFragment() {
     private lateinit var currentUser: User
     lateinit var builder: AlertDialog
 
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         profileViewModel.successfulUpdate.observe(this, Observer { successful ->
             (activity as MainActivity).hideProgressDialog()
@@ -112,10 +113,10 @@ class EditProfileFragment : DialogFragment() {
             if (currentUser != editProfileBinding.user && errors.isEmpty()) {
                 profileViewModel.updateProfile(editProfileBinding.user!!)
                 applicationClass.user = null
+                profileViewModel.deleteUserProfile()
             } else if (currentUser == editProfileBinding.user && errors.isEmpty()) {
                 builder.dismiss()
             }
-
         }
     }
 
@@ -153,4 +154,5 @@ class EditProfileFragment : DialogFragment() {
             onDismissListener.onDismiss(dialog)
         }
     }
+
 }

--- a/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
@@ -9,6 +9,7 @@ import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
+import org.systers.mentorship.applicationClass
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
@@ -36,39 +37,42 @@ class ProfileViewModel: ViewModel() {
      */
     @SuppressLint("CheckResult")
     fun getProfile() {
-        userDataManager.getUser()
-                .subscribeOn(Schedulers.newThread())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribeWith(object : DisposableObserver<User>() {
-                    override fun onNext(userprofile: User) {
-                        user = userprofile
-                        successfulGet.value = true
-                    }
-                    override fun onError(throwable: Throwable) {
-                        when (throwable) {
-                            is IOException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_please_check_internet)
-                            }
-                            is TimeoutException -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_request_timed_out)
-                            }
-                            is HttpException -> {
-                                message = CommonUtils.getErrorResponse(throwable).message
-                            }
-                            else -> {
-                                message = MentorshipApplication.getContext()
-                                        .getString(R.string.error_something_went_wrong)
-                                Log.e(tag, throwable.localizedMessage)
-                            }
+            userDataManager.getUser()
+                    .subscribeOn(Schedulers.newThread())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribeWith(object : DisposableObserver<User>() {
+                        override fun onNext(userprofile: User) {
+                            user = userprofile
+                            applicationClass.user = userprofile
+                            successfulGet.value = true
                         }
-                        successfulGet.value = false
-                    }
-                    override fun onComplete() {
-                    }
-                })
-    }
+                        override fun onError(throwable: Throwable) {
+                            when (throwable) {
+                                is IOException -> {
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_please_check_internet)
+                                }
+                                is TimeoutException -> {
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_request_timed_out)
+                                }
+                                is HttpException -> {
+                                    message = CommonUtils.getErrorResponse(throwable).message
+                                }
+                                else -> {
+                                    message = MentorshipApplication.getContext()
+                                            .getString(R.string.error_something_went_wrong)
+                                    Log.e(tag, throwable.localizedMessage)
+                                }
+                            }
+                            successfulGet.value = false
+                        }
+                        override fun onComplete() {
+                        }
+                    })
+        }
+
+
 
     /**
      * Updates the current user profile with data changed by the user

--- a/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
+++ b/app/src/main/java/org/systers/mentorship/viewmodels/ProfileViewModel.kt
@@ -1,15 +1,19 @@
 package org.systers.mentorship.viewmodels
 
 import android.annotation.SuppressLint
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import android.app.Application
 import android.util.Log
+import androidx.lifecycle.*
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.systers.mentorship.MentorshipApplication
 import org.systers.mentorship.R
 import org.systers.mentorship.applicationClass
+import org.systers.mentorship.data.userProfileDatabase
+import org.systers.mentorship.data.userProfileRepo
 import org.systers.mentorship.models.User
 import org.systers.mentorship.remote.datamanager.UserDataManager
 import org.systers.mentorship.remote.responses.CustomResponse
@@ -21,7 +25,7 @@ import java.util.concurrent.TimeoutException
 /**
  * This class represents the [ViewModel] used for ProfileFragment
  */
-class ProfileViewModel: ViewModel() {
+class ProfileViewModel(application: Application): AndroidViewModel(application) {
 
     var tag = ProfileViewModel::class.java.simpleName!!
 
@@ -31,6 +35,23 @@ class ProfileViewModel: ViewModel() {
     val successfulUpdate: MutableLiveData<Boolean> = MutableLiveData()
     lateinit var user: User
     lateinit var message: String
+    val getUserProfileFromDatabase: LiveData<User>
+    private val repo: userProfileRepo
+    init {
+        val UserDao = userProfileDatabase.getDatabase(application).userProfileDao()
+        repo = userProfileRepo(UserDao)
+        getUserProfileFromDatabase = repo.getUserProfile
+    }
+    fun storeUserProfile(userprofile: User){
+        viewModelScope.launch(Dispatchers.IO){
+            repo.storeUserProfile(userprofile)
+        }
+    }
+    fun deleteUserProfile(){
+        viewModelScope.launch(Dispatchers.IO) {
+            repo.deleteUserProfile()
+        }
+    }
 
     /**
      * Fetches the current users full profile

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,6 +29,7 @@ object Versions {
     const val appIntro = "5.1.0"
     const val appCompat = "1.0.2"
     const val circleImageView = "3.0.1"
+    const val roomVer = "2.2.6"
 }
 
 /**
@@ -61,4 +62,10 @@ object Dependencies {
     const val support_annotation = "androidx.annotation:annotation:${Versions.supportAnnotation}"
     const val app_intro = "com.github.AppIntro:AppIntro:${Versions.appIntro}"
     const val circule_image_view = "de.hdodenhof:circleimageview:${Versions.circleImageView}"
+    const val room_run = "androidx.room:room-runtime:${Versions.roomVer}"
+    const val room_com = "androidx.room:room-compiler:${Versions.roomVer}"
+    const val room_support = "androidx.room:room-ktx:${Versions.roomVer}"
+    const val room_test = "androidx.room:room-testing:${Versions.roomVer}"
+    const val lifecycle_common = "androidx.lifecycle:lifecycle-common-java8:${Versions.rxKotlin}"
+    const val lifecycle_viewmodel_ktx = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.rxKotlin}"
 }


### PR DESCRIPTION
### Description
Before every time the profile fragment was opened an API was called for User Information
In this PR - When the first time the app is opened the API is called for Profile Information all the data that we get from API is saved inside the Application class containing a companion object named user , so whenever the next time profile fragment is opened the Profile is retrieved from the Application class object user
Whenever the user edit/updates the profile the Application class User is also updated.

Fixes #714

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This has been tested locally 

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings

