### PR TITLE
Fix: Added toast message for "no skills' filter

### DIFF
--- a/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
@@ -140,6 +140,7 @@ class MembersFragment : BaseFragment() {
                                         Toast.LENGTH_SHORT).show()
                                 }
                             }
+                            //new code
                             if (!filterMap["skills"].isNullOrEmpty()) {
 
                                 val hasUsersWithSkills = membersViewModel.userList.any {

--- a/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
@@ -140,6 +140,17 @@ class MembersFragment : BaseFragment() {
                                         Toast.LENGTH_SHORT).show()
                                 }
                             }
+                            if (!filterMap["skills"].isNullOrEmpty()) {
+
+                                val hasUsersWithSkills = membersViewModel.userList.any {
+                                    (it.skills)?.contains(filterMap["skills"]!!, ignoreCase = true) == true
+                                }
+
+                                if (!hasUsersWithSkills) {
+                                    Toast.makeText(activity, getString(R.string.error_filter_not_found),
+                                        Toast.LENGTH_SHORT).show()
+                                }
+                            }
                         }
                         memberListInitialized = true
                         tvEmptyList.visibility = View.GONE

--- a/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
@@ -140,7 +140,7 @@ class MembersFragment : BaseFragment() {
                                         Toast.LENGTH_SHORT).show()
                                 }
                             }
-                            //new code
+
                             if (!filterMap["skills"].isNullOrEmpty()) {
 
                                 val hasUsersWithSkills = membersViewModel.userList.any {

--- a/app/src/main/java/org/anitab/mentorship/view/fragments/RequestsFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/RequestsFragment.kt
@@ -37,20 +37,25 @@ class RequestsFragment : BaseFragment() {
         setHasOptionsMenu(true)
         srlRequests.setOnRefreshListener { fetchNewest() }
 
-        requestsViewModel.successful.observe(viewLifecycleOwner, {
-            successful ->
+        requestsViewModel.successful.observe(viewLifecycleOwner) { successful ->
             srlRequests.isRefreshing = false
             if (successful != null) {
                 if (successful) {
-                    requestsViewModel.pendingSuccessful.observe(viewLifecycleOwner, {
-                        successful ->
+                    requestsViewModel.pendingSuccessful.observe(viewLifecycleOwner) { successful ->
                         activityCast.hideProgressDialog()
                         if (successful != null) {
                             if (successful) {
                                 requestsViewModel.allRequestsList?.let { allRequestsList ->
-                                    vpMentorshipRequests.adapter = RequestsPagerAdapter(allRequestsList, requestsViewModel.pendingAllRequestsList, requireActivity())
+                                    vpMentorshipRequests.adapter = RequestsPagerAdapter(
+                                        allRequestsList,
+                                        requestsViewModel.pendingAllRequestsList,
+                                        requireActivity()
+                                    )
 //                                    tlMentorshipRequests.setupWithViewPager(vpMentorshipRequests)
-                                    TabLayoutMediator(tlMentorshipRequests, vpMentorshipRequests) { tab, position ->
+                                    TabLayoutMediator(
+                                        tlMentorshipRequests,
+                                        vpMentorshipRequests
+                                    ) { tab, position ->
                                         when (position) {
                                             0 -> {
                                                 tab.text = context?.getString(R.string.pending)
@@ -66,7 +71,7 @@ class RequestsFragment : BaseFragment() {
                                 }
                             }
                         }
-                    })
+                    }
                 } else {
                     view?.let {
                         requestsViewModel.message?.let { message ->
@@ -75,7 +80,7 @@ class RequestsFragment : BaseFragment() {
                     }
                 }
             }
-        })
+        }
 
         fetchNewest()
     }

--- a/app/src/main/java/org/anitab/mentorship/view/fragments/TasksFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/TasksFragment.kt
@@ -5,6 +5,7 @@ import android.app.AlertDialog
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
@@ -142,7 +143,12 @@ class TasksFragment(private var mentorshipRelation: Relationship) : BaseFragment
 
         builder.setPositiveButton(appContext.getString(R.string.save)) { _, _ ->
             val editTextAddTask = dialogLayout.findViewById<EditText>(R.id.etAddTask)
-            taskViewModel.addTask(mentorshipRelation.id, CreateTask(editTextAddTask.text.toString()))
+
+            //Validation of Task Description text before posting it to backend
+            if(editTextAddTask.text.isEmpty())
+                Toast.makeText(context,"Task description is empty!!",Toast.LENGTH_SHORT).show();
+            else
+                taskViewModel.addTask(mentorshipRelation.id, CreateTask(editTextAddTask.text.toString()))
         }
         builder.setNegativeButton(appContext.getString(R.string.cancel)) { dialogInterface, i ->
             dialogInterface.dismiss()

--- a/app/src/main/java/org/anitab/mentorship/viewmodels/TasksViewModel.kt
+++ b/app/src/main/java/org/anitab/mentorship/viewmodels/TasksViewModel.kt
@@ -1,5 +1,7 @@
 package org.anitab.mentorship.viewmodels
 
+import android.app.Application
+import android.widget.Toast
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -56,8 +58,9 @@ class TasksViewModel : ViewModel() {
     fun addTask(relationId: Int, createTask: CreateTask) {
         viewModelScope.launch {
             try {
-                taskDataManager.addTask(relationId, createTask)
-                successfulAdd.postValue(true)
+                    taskDataManager.addTask(relationId, createTask)
+                    successfulAdd.postValue(true)
+
             } catch (throwable: Throwable) {
                 message = CommonUtils.getErrorMessage(throwable, tag)
                 successfulAdd.postValue(false)

--- a/app/src/main/res/layout/fragment_mentorship_tasks.xml
+++ b/app/src/main/res/layout/fragment_mentorship_tasks.xml
@@ -117,7 +117,10 @@
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
-        android:layout_margin="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
         android:gravity="bottom"
         app:srcCompat="@drawable/ic_add_black_24dp" />
 </RelativeLayout>


### PR DESCRIPTION
### Description

- Found similar code for "location filter"
- Copy pasted the same code below that

Fixes #866 

### Type of Change:

- Code

### How Has This Been Tested?

- Open app -> Go to members page -> open filter -> type anything on "skills" box that has zero results -> now it will show a toast message 


### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
