### PR TITLE
Change feedback page text color

### DIFF
--- a/app/src/main/res/layout/activity_feedback.xml
+++ b/app/src/main/res/layout/activity_feedback.xml
@@ -26,6 +26,7 @@
                 android:layout_marginEnd="16dp"
                 android:text="@string/feedback_sendfeedback"
                 android:textAppearance="@style/TextAppearance.AppCompat.Title"
+                android:textColor="#55111109"
                 android:textSize="30sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_feedback.xml
+++ b/app/src/main/res/layout/activity_feedback.xml
@@ -26,7 +26,7 @@
                 android:layout_marginEnd="16dp"
                 android:text="@string/feedback_sendfeedback"
                 android:textAppearance="@style/TextAppearance.AppCompat.Title"
-                android:textColor="#55111109"
+                android:textColor="@color/aubergine"
                 android:textSize="30sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### Description
Change the colour of "Send us your feedback!" on the Feedback page from black to #55111109

Fixes https://github.com/anitab-org/mentorship-android/issues/1200

### Type of Change:
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<img width="319" alt="image" src="https://user-images.githubusercontent.com/52749105/177703027-aaf0f8f2-7ab9-4f95-bca9-f4f4bd5e6d57.png">


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
