### PR TITLE
Added toast message for "no skills" filter

### DIFF
--- a/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
@@ -140,6 +140,17 @@ class MembersFragment : BaseFragment() {
                                         Toast.LENGTH_SHORT).show()
                                 }
                             }
+                            if (!filterMap["skills"].isNullOrEmpty()) {
+
+                                val hasUsersWithSkills = membersViewModel.userList.any {
+                                    (it.skills)?.contains(filterMap["skills"]!!, ignoreCase = true) == true
+                                }
+
+                                if (!hasUsersWithSkills) {
+                                    Toast.makeText(activity, getString(R.string.error_filter_not_found),
+                                        Toast.LENGTH_SHORT).show()
+                                }
+                            }
                         }
                         memberListInitialized = true
                         tvEmptyList.visibility = View.GONE

--- a/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
+++ b/app/src/main/java/org/anitab/mentorship/view/fragments/MembersFragment.kt
@@ -140,17 +140,6 @@ class MembersFragment : BaseFragment() {
                                         Toast.LENGTH_SHORT).show()
                                 }
                             }
-                            if (!filterMap["skills"].isNullOrEmpty()) {
-
-                                val hasUsersWithSkills = membersViewModel.userList.any {
-                                    (it.skills)?.contains(filterMap["skills"]!!, ignoreCase = true) == true
-                                }
-
-                                if (!hasUsersWithSkills) {
-                                    Toast.makeText(activity, getString(R.string.error_filter_not_found),
-                                        Toast.LENGTH_SHORT).show()
-                                }
-                            }
                         }
                         memberListInitialized = true
                         tvEmptyList.visibility = View.GONE


### PR DESCRIPTION
### Description
<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

• Added "Skill Filter" similar to "Location Filter"

Fixes #866 

### Type of Change:
<!--- **Delete irrelevant options.** --->

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->

Tested on
Device: Redmi Note 10 Pro
OS: Android 11

Instructions to reproduce the behaviour:
• Open App -> Login using credentials -> Go to Members Page -> Open Filter option -> Enter anything into the "Skills" box that will show zero results -> Toast message pops up


### Checklist:
<!--- **Delete irrelevant options.** --->

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [X] My changes generate no new warnings

